### PR TITLE
Code restructuring of StatisticServer Opendata APIs - enable swagger, xlsx

### DIFF
--- a/RMBTStatisticServer/build.gradle
+++ b/RMBTStatisticServer/build.gradle
@@ -96,6 +96,12 @@ swagger {
         info {
             title = 'RTR NetTest OpenData'
             version = 'v1'
+            description = 'Open Data API for RTR-Netztest\n ' +
+                    'For further information, please consult <https://www.netztest.at/en/Opendata>\n ' +
+                    'For high-volume requests, please contact RTR (netztest@rtr.at) for instructions regarding the parameter "sender". ' +
+                    'Users with a registered sender ID can be informed in case of major interface changes.\n ' +
+                    'Data accessible via the Open Data Interface are made available under Creative Commons Attribution 4.0 (CC BY 4.0). ' +
+                    'Regarding privacy policy and terms of use, please refer to https://www.rtr.at/en/tk/netztestterms.'
             contact {
                 email = 'netztest@rtr.at'
                 name = 'RTR-Netztest-Team'

--- a/RMBTStatisticServer/build.gradle
+++ b/RMBTStatisticServer/build.gradle
@@ -64,7 +64,7 @@ dependencies {
     compile 'commons-io:commons-io:2.4'
     compile 'org.apache.jcs:jcs:1.3'
     compile 'io.swagger:swagger-annotations:1.5.15'
-    compile 'io.swagger:swagger-core:1.5.15'
+    //compile 'io.swagger:swagger-core:1.5.15'
     compile 'javax.ws.rs:javax.ws.rs-api:2.0.1'
     compile 'com.fasterxml.jackson:jackson-base:2.9.7'
     compile 'com.fasterxml.jackson.dataformat:jackson-dataformat-csv:2.9.7'
@@ -106,9 +106,7 @@ swagger {
                 name = 'Apache 2.0'
             }
         }
-
-        outputPath = "${project.rootDir}/generated/document.html"
-        swaggerDirectory = "${project.rootDir}/generated/"
+        swaggerDirectory = "${project.rootDir}/RMBTStatisticServer/doc/"
         outputFormats = ['json']
     }
 }

--- a/RMBTStatisticServer/build.gradle
+++ b/RMBTStatisticServer/build.gradle
@@ -4,6 +4,11 @@ buildscript {
     }
 }
 
+plugins {
+    id "com.benjaminsproule.swagger" version "1.0.4"
+}
+
+apply plugin: 'com.benjaminsproule.swagger'
 apply plugin: 'war'
 sourceCompatibility = '1.7'
 
@@ -58,6 +63,9 @@ dependencies {
     compile 'org.apache.commons:commons-csv:1.4'
     compile 'commons-io:commons-io:2.4'
     compile 'org.apache.jcs:jcs:1.3'
+    compile 'io.swagger:swagger-annotations:1.5.15'
+    compile 'io.swagger:swagger-core:1.5.15'
+    compile 'javax.ws.rs:javax.ws.rs-api:2.0.1'
     compile 'com.fasterxml.jackson:jackson-base:2.9.7'
     compile 'com.fasterxml.jackson.dataformat:jackson-dataformat-csv:2.9.7'
     compile group: 'commons-dbutils', name: 'commons-dbutils', version: '1.7'
@@ -74,6 +82,34 @@ war {
     from(buildDir){ 
             into('META-INF') 
             include 'context.xml' 
+    }
+}
+
+
+swagger {
+    apiSource {
+        springmvc = false
+        locations = ['at.rtr.rmbt.statisticServer']
+        schemes = ['https']
+        host = 'data.netztest.at'
+        basePath = '/RMBTStatisticServer'
+        info {
+            title = 'RTR NetTest OpenData'
+            version = 'v1'
+            contact {
+                email = 'netztest@rtr.at'
+                name = 'RTR-Netztest-Team'
+                url = 'https://www.netztest.at'
+            }
+            license {
+                url = 'http://www.apache.org/licenses/LICENSE-2.0.html'
+                name = 'Apache 2.0'
+            }
+        }
+
+        outputPath = "${project.rootDir}/generated/document.html"
+        swaggerDirectory = "${project.rootDir}/generated/"
+        outputFormats = ['json']
     }
 }
 

--- a/RMBTStatisticServer/build.gradle
+++ b/RMBTStatisticServer/build.gradle
@@ -17,6 +17,7 @@ repositories {
     mavenCentral()
     maven{url 'http://maven.restlet.com'}
     maven{url 'https://oss.sonatype.org/content/repositories/snapshots/'}
+    maven { url 'https://jitpack.io' }
 }
 
 sourceSets {
@@ -59,7 +60,8 @@ dependencies {
     compile 'org.apache.jcs:jcs:1.3'
     compile 'com.fasterxml.jackson:jackson-base:2.9.7'
     compile 'com.fasterxml.jackson.dataformat:jackson-dataformat-csv:2.9.7'
-    compile group: 'commons-dbutils', name: 'commons-dbutils', version: '1.7'    
+    compile group: 'commons-dbutils', name: 'commons-dbutils', version: '1.7'
+    compile 'com.github.sett4:jackson-dataformat-xlsx-lite:2.9.6-1'
     compile project(':RMBTSharedCode')
     compile project(':RMBTUtil')
 }

--- a/RMBTStatisticServer/build.gradle
+++ b/RMBTStatisticServer/build.gradle
@@ -57,6 +57,9 @@ dependencies {
     compile 'org.apache.commons:commons-csv:1.4'
     compile 'commons-io:commons-io:2.4'
     compile 'org.apache.jcs:jcs:1.3'
+    compile 'com.fasterxml.jackson:jackson-base:2.9.7'
+    compile 'com.fasterxml.jackson.dataformat:jackson-dataformat-csv:2.9.7'
+    compile group: 'commons-dbutils', name: 'commons-dbutils', version: '1.7'    
     compile project(':RMBTSharedCode')
     compile project(':RMBTUtil')
 }

--- a/RMBTStatisticServer/build.gradle
+++ b/RMBTStatisticServer/build.gradle
@@ -60,7 +60,6 @@ dependencies {
     compile 'org.restlet.jse:org.restlet.ext.json:2.1.7'
     compile 'org.restlet.jee:org.restlet.ext.servlet:2.1.7'
     compile 'org.json:json:20140107'
-    compile 'org.apache.commons:commons-csv:1.4'
     compile 'commons-io:commons-io:2.4'
     compile 'org.apache.jcs:jcs:1.3'
     compile 'io.swagger:swagger-annotations:1.5.15'

--- a/RMBTStatisticServer/doc/swagger.json
+++ b/RMBTStatisticServer/doc/swagger.json
@@ -1,0 +1,1439 @@
+{
+  "swagger" : "2.0",
+  "info" : {
+    "description" : "Open Data API for RTR-Netztest\n For further information, please consult <https://www.netztest.at/en/Opendata>\n For high-volume requests, please contact RTR (netztest@rtr.at) for instructions regarding the parameter \"sender\". Users with a registered sender ID can be informed in case of major interface changes.\n Data accessible via the Open Data Interface are made available under Creative Commons Attribution 4.0 (CC BY 4.0). Regarding privacy policy and terms of use, please refer to https://www.rtr.at/en/tk/netztestterms.",
+    "version" : "v1",
+    "title" : "RTR NetTest OpenData",
+    "contact" : {
+      "name" : "RTR-Netztest-Team",
+      "url" : "https://www.netztest.at",
+      "email" : "netztest@rtr.at"
+    },
+    "license" : {
+      "name" : "Apache 2.0",
+      "url" : "http://www.apache.org/licenses/LICENSE-2.0.html"
+    }
+  },
+  "host" : "data.netztest.at",
+  "basePath" : "/RMBTStatisticServer",
+  "tags" : [ {
+    "name" : "export"
+  }, {
+    "name" : "opentests"
+  }, {
+    "name" : "opentestssearch"
+  } ],
+  "schemes" : [ "https" ],
+  "paths" : {
+    "/export/netztest-opendata-{year}-{month}.{format}" : {
+      "get" : {
+        "tags" : [ "export" ],
+        "summary" : "Export open data as CSV or XLSX",
+        "description" : "Bulk export open data entries",
+        "operationId" : "export",
+        "parameters" : [ {
+          "name" : "year",
+          "in" : "path",
+          "description" : "Mandatory. The year that should be exported.",
+          "required" : true,
+          "type" : "string",
+          "x-example" : "2017"
+        }, {
+          "name" : "month",
+          "in" : "path",
+          "description" : "Mandatory. The year that should be exported.",
+          "required" : true,
+          "type" : "integer",
+          "x-example" : 0
+        }, {
+          "name" : "format",
+          "in" : "path",
+          "description" : "Mandatory. Either ZIP (CSV) or XLSX.",
+          "required" : true,
+          "type" : "string",
+          "x-example" : "xlsx"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/OpenTestExportDTO"
+            }
+          }
+        }
+      }
+    },
+    "/opentests/search" : {
+      "get" : {
+        "tags" : [ "opentestssearch" ],
+        "summary" : "Search for open data tests",
+        "description" : "Date fields have to be submitted as a number, representing the number of milliseconds that have elapsed since midnight, January 1st, 1970 or in the format “yyyy-MM-dd HH:mm:ss”. The time is given in UTC.\n\nDecimal point (Full Stop “.”) is always used to separate the integer part from the fractional part of a number written in decimal form. This is independent from the local or regional settings.\n\nNumeric fields also allow using the comparators ‘>’ and ‘<’ (meaning ‘=>’ and ‘=<’ respectively). Dates have always to be queried as ranges by using these comparators.\n\nString fields allow using the wildcard ‘*’ for matching any literals and ‘?’ for matching one arbitrary literal.\n\nIt is possible, to begin each filter argument with an exclamation mark (!) to negate the filter. E.g. network_type=!LAN will yield all tests where the network type was not LAN.\n\nThe criteria denoted with [] can be used more than once in a query. Data has to match all criteria. If an array for one criterion is given, the data has to match each entry.\n\nGenerally a query on a parameter value ‘null’ is not possible, except for the parameter loc_accuracy, where the value -1 means ‘null’. Non-‘null’ values are queried with any single or multiple values.",
+        "operationId" : "search",
+        "parameters" : [ {
+          "name" : "download_kbit",
+          "in" : "query",
+          "description" : "Download speed in kilobit per second",
+          "required" : false,
+          "type" : "string",
+          "x-example" : ">6903"
+        }, {
+          "name" : "upload_kbit",
+          "in" : "query",
+          "description" : "Upload speed in kilobit per second.",
+          "required" : false,
+          "type" : "string",
+          "x-example" : "<4670"
+        }, {
+          "name" : "ping_ms",
+          "in" : "query",
+          "description" : "Median ping (round-trip time) in milliseconds, measured on the server side. In previous versions (before June 3rd 2015) this was the minimum ping measured on the client side.",
+          "required" : false,
+          "type" : "string",
+          "x-example" : "<16"
+        }, {
+          "name" : "gkz",
+          "in" : "query",
+          "description" : "Community ID (Gemeindekennzahl, see <http://www.bev.gv.at/portal/page?_pageid=713,2601287&_dad=portal&_schema=PORTAL>).",
+          "required" : false,
+          "type" : "string"
+        }, {
+          "name" : "gkz_sa",
+          "in" : "query",
+          "description" : "Community ID (Gemeindekennzahl, see <http://www.statistik.at/web_de/klassifikationen/regionale_gliederungen/gemeinden/index.html>)",
+          "required" : false,
+          "type" : "string"
+        }, {
+          "name" : "cat_technology",
+          "in" : "query",
+          "description" : "Technology category of the network, e.g. “3G”, “4G”, “WLAN”.",
+          "required" : false,
+          "type" : "string"
+        }, {
+          "name" : "client_version",
+          "in" : "query",
+          "description" : "Software version number of the client.",
+          "required" : false,
+          "type" : "string"
+        }, {
+          "name" : "model",
+          "in" : "query",
+          "description" : "Name of the device used.",
+          "required" : false,
+          "type" : "string"
+        }, {
+          "name" : "network_name",
+          "in" : "query",
+          "description" : "Display name of the mobile network.",
+          "required" : false,
+          "type" : "string"
+        }, {
+          "name" : "network_type",
+          "in" : "query",
+          "description" : "Type of the network, e.g. MOBILE, LAN, WLAN.",
+          "required" : false,
+          "type" : "string"
+        }, {
+          "name" : "platform",
+          "in" : "query",
+          "description" : "Platform on which the test has been conducted",
+          "required" : false,
+          "type" : "string"
+        }, {
+          "name" : "signal_strength",
+          "in" : "query",
+          "description" : "Signal strength (RSSI) in dBm.",
+          "required" : false,
+          "type" : "string"
+        }, {
+          "name" : "open_uuid",
+          "in" : "query",
+          "description" : "Open-UUID: Identifies the client that conducted the test. The a new Open-UUID is assigned to the client on a regular basis.",
+          "required" : false,
+          "type" : "string"
+        }, {
+          "name" : "open_test_uuid",
+          "in" : "query",
+          "description" : "The UUID of the test.",
+          "required" : false,
+          "type" : "string"
+        }, {
+          "name" : "client_uuid",
+          "in" : "query",
+          "description" : "The private UUID of a client",
+          "required" : false,
+          "type" : "string"
+        }, {
+          "name" : "test_uuid",
+          "in" : "query",
+          "description" : "The private UUID of a test",
+          "required" : false,
+          "type" : "string"
+        }, {
+          "name" : "long",
+          "in" : "query",
+          "description" : "Longitude of the client position.",
+          "required" : false,
+          "type" : "number"
+        }, {
+          "name" : "lat",
+          "in" : "query",
+          "description" : "Latitude of the client position.",
+          "required" : false,
+          "type" : "number"
+        }, {
+          "name" : "radius",
+          "in" : "query",
+          "description" : "Radius in meters defining based on lat/long parameters",
+          "required" : false,
+          "type" : "string"
+        }, {
+          "name" : "mobile_provider_name",
+          "in" : "query",
+          "description" : "mobile operator name",
+          "required" : false,
+          "type" : "string"
+        }, {
+          "name" : "provider_name",
+          "in" : "query",
+          "description" : "Name of the internet service provider.",
+          "required" : false,
+          "type" : "string"
+        }, {
+          "name" : "sim_mcc_mnc",
+          "in" : "query",
+          "description" : "Network identification of the SIM provider. The digits of MCC and MNC have the same meaning as described in “network_mcc_mnc”.",
+          "required" : false,
+          "type" : "string"
+        }, {
+          "name" : "sim_country",
+          "in" : "query",
+          "description" : "Home country of the SIM card in ISO 3166.",
+          "required" : false,
+          "type" : "string"
+        }, {
+          "name" : "network_country",
+          "in" : "query",
+          "description" : "Country of the network in ISO 3166.",
+          "required" : false,
+          "type" : "string"
+        }, {
+          "name" : "country_geoip",
+          "in" : "query",
+          "description" : "Country according client IP address.",
+          "required" : false,
+          "type" : "string"
+        }, {
+          "name" : "country_location",
+          "in" : "query",
+          "description" : "Country of geo-location.",
+          "required" : false,
+          "type" : "string"
+        }, {
+          "name" : "user_server_selection",
+          "in" : "query",
+          "description" : "Legacy",
+          "required" : false,
+          "type" : "boolean"
+        }, {
+          "name" : "loc_accuracy",
+          "in" : "query",
+          "description" : "Estimation of accuracy of client location in meters",
+          "required" : false,
+          "type" : "string"
+        }, {
+          "name" : "public_ip_as_name",
+          "in" : "query",
+          "description" : "Name of the AS of the clients public IP.",
+          "required" : false,
+          "type" : "string"
+        }, {
+          "name" : "time",
+          "in" : "query",
+          "description" : "UTC date and time when test was started.",
+          "required" : false,
+          "type" : "string"
+        }, {
+          "name" : "radio_band",
+          "in" : "query",
+          "description" : "Radio band used when conducting the test.",
+          "required" : false,
+          "type" : "integer",
+          "format" : "int64"
+        }, {
+          "name" : "cell_area_code",
+          "in" : "query",
+          "description" : "Number describing the coarse location of a cell. E.g. the Tracking Area Code (TAC) in case of 4G or the Location Area Code (LAC) in case of 2G or 3G",
+          "required" : false,
+          "type" : "integer",
+          "format" : "int64"
+        }, {
+          "name" : "cell_location_id",
+          "in" : "query",
+          "description" : "Number identifying the location of a cell. E.g. the 28-bit Cell Identity (CI) in case of 4G, the 28-bit UMTS Cell Identity (CID) in case of UMTS or the 16-bit GSM Cell Identity (CID) in case of GSM.",
+          "required" : false,
+          "type" : "integer",
+          "format" : "int64"
+        }, {
+          "name" : "additional_info",
+          "in" : "query",
+          "description" : "additional properties to return",
+          "required" : false,
+          "type" : "string",
+          "x-example" : "download_classification"
+        }, {
+          "name" : "format",
+          "in" : "query",
+          "description" : "Desired output format, either 'csv' or 'json', default: json",
+          "required" : false,
+          "type" : "string",
+          "x-example" : "json"
+        }, {
+          "name" : "sort_by",
+          "in" : "query",
+          "description" : "The field for which the data are sorted. Valid fields are: “download_kbit\", \"upload_kbit\", \"time\", \"signal_strength\" and \"ping_ms\"",
+          "required" : false,
+          "type" : "string",
+          "x-example" : "download_kbit"
+        }, {
+          "name" : "sort_order",
+          "in" : "query",
+          "description" : "The sort_by-Parameter specifies the field, the sort_order-Parameter specifies the direction ('asc' or 'desc').\n Per Default, the results are sorted by the time of the test in descending order (i.e. sort_by=time&sort_order=desc).\n If the sort parameters are specified, the value of the cursor is a multiple of the parameter max_results, otherwise it is an arbitrary number.",
+          "required" : false,
+          "type" : "string",
+          "x-example" : "asc"
+        }, {
+          "name" : "max_results",
+          "in" : "query",
+          "description" : "This is the page size, i.e. maximum number of result items that are returned per page.\n The default value is 100 items per page. The page size limit is 10000 items, i.e. not more than 10000 results can be displayed in a page.",
+          "required" : false,
+          "type" : "integer",
+          "x-example" : 10
+        }, {
+          "name" : "cursor",
+          "in" : "query",
+          "description" : "used for pagination if the query returns more than the number of items according to parameter max_results. The value to be used for the display of the next page is given by the previous response in returned parameter next_cursor.",
+          "required" : false,
+          "type" : "string"
+        }, {
+          "name" : "sender",
+          "in" : "query",
+          "description" : "Sender ID",
+          "required" : false,
+          "type" : "string"
+        }, {
+          "name" : "timestamp",
+          "in" : "query",
+          "description" : "Alias '_'. Will be ignored and can be used to prevent caching of the response.",
+          "required" : false,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/OpenTestSearchDTO"
+            }
+          }
+        }
+      }
+    },
+    "/opentests/{open-test-uuid}" : {
+      "get" : {
+        "tags" : [ "opentests" ],
+        "summary" : "query for OpenTests",
+        "description" : "Query for a specific measurement result",
+        "operationId" : "opentest-query",
+        "parameters" : [ {
+          "name" : "open-test-uuid",
+          "in" : "path",
+          "description" : "Mandatory. The open-test-uuid of the test.",
+          "required" : true,
+          "type" : "string",
+          "x-example" : "Oc1326b7c-4141-42cb-b8c5-922c356a6cee"
+        }, {
+          "name" : "verbose",
+          "in" : "query",
+          "description" : "Optional. If >0 the threadwise speed curve is additionally returned.",
+          "required" : false,
+          "type" : "integer",
+          "x-example" : 0
+        }, {
+          "name" : "sender",
+          "in" : "query",
+          "description" : "Optional. ID of the sender, for authentification.",
+          "required" : false,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/OpenTestDetailsDTO"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions" : {
+    "CellInfo2G" : {
+      "type" : "object",
+      "properties" : {
+        "lac" : {
+          "type" : "integer",
+          "format" : "int32",
+          "example" : 47170,
+          "description" : "16-bit Location Area Code, 0..65535"
+        },
+        "cid" : {
+          "type" : "integer",
+          "format" : "int32",
+          "example" : 18804,
+          "description" : "16-bit GSM Cell Identity described in TS 27.007, 0..65535"
+        },
+        "bsic" : {
+          "type" : "integer",
+          "format" : "int32",
+          "example" : 58,
+          "description" : "6-bit Base Station Identity Code"
+        },
+        "arfcn" : {
+          "type" : "integer",
+          "format" : "int32",
+          "example" : 1021,
+          "description" : "16-bit GSM Absolute RF Channel Number"
+        },
+        "frequency_dl" : {
+          "type" : "number",
+          "format" : "double",
+          "example" : 934.4,
+          "description" : "Frequency of the downlink in MHz",
+          "readOnly" : true
+        },
+        "band" : {
+          "type" : "integer",
+          "format" : "int32",
+          "example" : 1,
+          "description" : "Band",
+          "readOnly" : true
+        }
+      }
+    },
+    "CellInfo3G" : {
+      "type" : "object",
+      "properties" : {
+        "lac" : {
+          "type" : "integer",
+          "format" : "int32",
+          "example" : 2510,
+          "description" : "16-bit Location Area Code, 0..65535"
+        },
+        "cid" : {
+          "type" : "integer",
+          "format" : "int32",
+          "example" : 9908484,
+          "description" : "CID 28-bit UMTS Cell Identity described in TS 25.331, 0..268435455"
+        },
+        "psc" : {
+          "type" : "integer",
+          "format" : "int32",
+          "example" : 27,
+          "description" : "9-bit UMTS Primary Scrambling Code described in TS 25.331, 0..511"
+        },
+        "uarfcn" : {
+          "type" : "integer",
+          "format" : "int32",
+          "example" : 10687,
+          "description" : "16-bit UMTS Absolute RF Channel Number"
+        },
+        "frequency_dl" : {
+          "type" : "number",
+          "format" : "double",
+          "example" : 934.4,
+          "description" : "Frequency of the downlink in MHz",
+          "readOnly" : true
+        },
+        "band" : {
+          "type" : "integer",
+          "format" : "int32",
+          "example" : 1,
+          "description" : "Band",
+          "readOnly" : true
+        }
+      }
+    },
+    "CellInfo4G" : {
+      "type" : "object",
+      "properties" : {
+        "tac" : {
+          "type" : "integer",
+          "format" : "int32",
+          "example" : 6710,
+          "description" : "16-bit Tracking Area Code"
+        },
+        "ci" : {
+          "type" : "integer",
+          "format" : "int32",
+          "example" : 189954,
+          "description" : "28-bit Cell Identity"
+        },
+        "pci" : {
+          "type" : "integer",
+          "format" : "int32",
+          "example" : 35,
+          "description" : "Physical Cell Id 0..503"
+        },
+        "earfcn" : {
+          "type" : "integer",
+          "format" : "int32",
+          "example" : 2850,
+          "description" : "18-bit Absolute RF Channel Number"
+        },
+        "frequency_dl" : {
+          "type" : "number",
+          "format" : "double",
+          "example" : 934.4,
+          "description" : "Frequency of the downlink in MHz",
+          "readOnly" : true
+        },
+        "band" : {
+          "type" : "integer",
+          "format" : "int32",
+          "example" : 1,
+          "description" : "Band",
+          "readOnly" : true
+        }
+      }
+    },
+    "LocationGraphItem" : {
+      "type" : "object",
+      "properties" : {
+        "bearing" : {
+          "type" : "number",
+          "format" : "double",
+          "example" : 195.4,
+          "description" : "Direction of travel of the hosting device in degrees, where 0° ≤ bearing < 360°, counting clockwise relative to the true north"
+        },
+        "speed" : {
+          "type" : "number",
+          "format" : "double",
+          "example" : 22.4,
+          "description" : "Speed of the client device in meters per second"
+        },
+        "altitude" : {
+          "type" : "number",
+          "format" : "double",
+          "example" : 300.4,
+          "description" : "Altitude of the client position in meters"
+        },
+        "long" : {
+          "type" : "number",
+          "format" : "double",
+          "example" : 14.20882799,
+          "description" : "Longitude of the client position."
+        },
+        "lat" : {
+          "type" : "number",
+          "format" : "double",
+          "example" : 47.76077786,
+          "description" : "Latitude of the client position."
+        },
+        "loc_accuracy" : {
+          "type" : "number",
+          "format" : "double",
+          "example" : 8.0,
+          "description" : "Estimation of accuracy of client location."
+        },
+        "time_elapsed" : {
+          "type" : "integer",
+          "format" : "int64",
+          "example" : 55,
+          "description" : "The time elapsed since the start of the test in milliseconds."
+        },
+        "loc_src" : {
+          "type" : "string",
+          "example" : "gps",
+          "description" : "Source for the geo location-data. Values: “gps”, “network”."
+        }
+      }
+    },
+    "OpenTestDTO" : {
+      "type" : "object",
+      "properties" : {
+        "open_uuid" : {
+          "type" : "string",
+          "example" : "P9f2b7bb1-39ea-454e-aa97-538564d7f8f1",
+          "description" : "Open UUID identifying a test"
+        },
+        "open_test_uuid" : {
+          "type" : "string",
+          "example" : "Oa1f286be-3c91-4f7d-b3d3-29d0e143e20d",
+          "description" : "Open UUID identifying a user"
+        },
+        "time" : {
+          "type" : "string",
+          "example" : "2018-07-15 01:55"
+        },
+        "lat" : {
+          "type" : "number",
+          "format" : "double",
+          "example" : 48.2029024,
+          "description" : "Latitude of the client position."
+        },
+        "long" : {
+          "type" : "number",
+          "format" : "double",
+          "example" : 16.3967841,
+          "description" : "Longitude of the client position."
+        },
+        "download_kbit" : {
+          "type" : "integer",
+          "format" : "int64",
+          "example" : 6903,
+          "description" : "Download speed in kilobit per second"
+        },
+        "upload_kbit" : {
+          "type" : "integer",
+          "format" : "int64",
+          "example" : 1565,
+          "description" : "Upload speed in kilobit per second"
+        },
+        "ping_ms" : {
+          "type" : "number",
+          "format" : "double",
+          "example" : 16.178334,
+          "description" : "Median ping (round-trip time) in milliseconds, measured on the server side. In previous versions (before June 3rd 2015) this was the minimum ping measured on the client side."
+        },
+        "signal_strength" : {
+          "type" : "integer",
+          "format" : "int32",
+          "example" : -56,
+          "description" : "Signal strength (RSSI) in dBm."
+        },
+        "lte_rsrp" : {
+          "type" : "integer",
+          "format" : "int32",
+          "example" : -81,
+          "description" : "LTE signal strength in dBm."
+        },
+        "platform" : {
+          "type" : "string",
+          "example" : "RMBTws",
+          "description" : "Platform on which the test has been conducted. E.g.\n* “Android” (= Google Android App),\n* “iOS” (= Apple iOs App),\n* Applet (= Java applet test within a browser),\n* RMBTjs (= simple JavaScript test within a browser, without Java),\n* RMBTws (= advanced JavaScript test using WebSockets within the browser).\n"
+        },
+        "provider_name" : {
+          "type" : "string",
+          "example" : "Provider",
+          "description" : "Name of the internet service provider."
+        },
+        "model" : {
+          "type" : "string",
+          "example" : "Sony Xperia Tablet Z LTE",
+          "description" : "Name of the device used."
+        },
+        "loc_accuracy" : {
+          "type" : "number",
+          "format" : "double",
+          "example" : 15.28,
+          "description" : "Estimation of accuracy of client location in meters"
+        },
+        "download_classification" : {
+          "type" : "integer",
+          "format" : "int32",
+          "example" : 2,
+          "description" : "Classification for the download speed in a traffic-light system.\n\n0 = unknown, 1 = red, 2 = yellow, 3 = green."
+        },
+        "upload_classification" : {
+          "type" : "integer",
+          "format" : "int32",
+          "example" : 1,
+          "description" : "Classification for the upload speed in a traffic-light system.\n\n0 = unknown, 1 = red, 2 = yellow, 3 = green."
+        },
+        "ping_classification" : {
+          "type" : "integer",
+          "format" : "int32",
+          "example" : 3,
+          "description" : "Classification for the ping speed in a traffic-light system.\n\n0 = unknown, 1 = red, 2 = yellow, 3 = green."
+        }
+      }
+    },
+    "OpenTestDetailsDTO" : {
+      "type" : "object",
+      "properties" : {
+        "open_uuid" : {
+          "type" : "string",
+          "example" : "P9f2b7bb1-39ea-454e-aa97-538564d7f8f1",
+          "description" : "Open UUID identifying a test"
+        },
+        "open_test_uuid" : {
+          "type" : "string",
+          "example" : "Oa1f286be-3c91-4f7d-b3d3-29d0e143e20d",
+          "description" : "Open UUID identifying a user"
+        },
+        "time" : {
+          "type" : "string",
+          "example" : "2018-07-15 01:55"
+        },
+        "lat" : {
+          "type" : "number",
+          "format" : "double",
+          "example" : 48.2029024,
+          "description" : "Latitude of the client position."
+        },
+        "long" : {
+          "type" : "number",
+          "format" : "double",
+          "example" : 16.3967841,
+          "description" : "Longitude of the client position."
+        },
+        "download_kbit" : {
+          "type" : "integer",
+          "format" : "int64",
+          "example" : 6903,
+          "description" : "Download speed in kilobit per second"
+        },
+        "upload_kbit" : {
+          "type" : "integer",
+          "format" : "int64",
+          "example" : 1565,
+          "description" : "Upload speed in kilobit per second"
+        },
+        "ping_ms" : {
+          "type" : "number",
+          "format" : "double",
+          "example" : 16.178334,
+          "description" : "Median ping (round-trip time) in milliseconds, measured on the server side. In previous versions (before June 3rd 2015) this was the minimum ping measured on the client side."
+        },
+        "signal_strength" : {
+          "type" : "integer",
+          "format" : "int32",
+          "example" : -56,
+          "description" : "Signal strength (RSSI) in dBm."
+        },
+        "lte_rsrp" : {
+          "type" : "integer",
+          "format" : "int32",
+          "example" : -81,
+          "description" : "LTE signal strength in dBm."
+        },
+        "platform" : {
+          "type" : "string",
+          "example" : "RMBTws",
+          "description" : "Platform on which the test has been conducted. E.g.\n* “Android” (= Google Android App),\n* “iOS” (= Apple iOs App),\n* Applet (= Java applet test within a browser),\n* RMBTjs (= simple JavaScript test within a browser, without Java),\n* RMBTws (= advanced JavaScript test using WebSockets within the browser).\n"
+        },
+        "provider_name" : {
+          "type" : "string",
+          "example" : "Provider",
+          "description" : "Name of the internet service provider."
+        },
+        "model" : {
+          "type" : "string",
+          "example" : "Sony Xperia Tablet Z LTE",
+          "description" : "Name of the device used."
+        },
+        "loc_accuracy" : {
+          "type" : "number",
+          "format" : "double",
+          "example" : 15.28,
+          "description" : "Estimation of accuracy of client location in meters"
+        },
+        "download_classification" : {
+          "type" : "integer",
+          "format" : "int32",
+          "example" : 2,
+          "description" : "Classification for the download speed in a traffic-light system.\n\n0 = unknown, 1 = red, 2 = yellow, 3 = green."
+        },
+        "upload_classification" : {
+          "type" : "integer",
+          "format" : "int32",
+          "example" : 1,
+          "description" : "Classification for the upload speed in a traffic-light system.\n\n0 = unknown, 1 = red, 2 = yellow, 3 = green."
+        },
+        "distance" : {
+          "type" : "number",
+          "format" : "double",
+          "example" : 134.0,
+          "description" : "The distance that the user moved in meters."
+        },
+        "error" : {
+          "type" : "string"
+        },
+        "ping_classification" : {
+          "type" : "integer",
+          "format" : "int32",
+          "example" : 3,
+          "description" : "Classification for the ping speed in a traffic-light system.\n\n0 = unknown, 1 = red, 2 = yellow, 3 = green."
+        },
+        "cat_technology" : {
+          "type" : "string",
+          "example" : "4G",
+          "description" : "Technology category of the network, e.g. “3G”, “4G”, “WLAN”."
+        },
+        "network_type" : {
+          "type" : "string",
+          "example" : "WLAN",
+          "description" : "Type of the network, e.g. MOBILE, LAN, WLAN."
+        },
+        "loc_src" : {
+          "type" : "string",
+          "example" : "gps",
+          "description" : "Source for the geo location-data. Values: “gps”, “network”.",
+          "enum" : [ "gps", "network" ]
+        },
+        "public_ip_as_name" : {
+          "type" : "string",
+          "example" : "AS32768 Provider",
+          "description" : "Name of the AS of the clients public IP."
+        },
+        "zip_code" : {
+          "type" : "integer",
+          "format" : "int64",
+          "description" : "Obsolete, always 'null'"
+        },
+        "kg_nr" : {
+          "type" : "integer",
+          "format" : "int64",
+          "example" : 1009,
+          "description" : "Number of the cadastral community, see <http://www.bev.gv.at/portal/page?_pageid=713,2601287&_dad=portal&_schema=PORTAL>"
+        },
+        "gkz" : {
+          "type" : "integer",
+          "format" : "int64",
+          "example" : 90001,
+          "description" : "Community ID (Gemeindekennzahl, see <http://www.bev.gv.at/portal/page?_pageid=713,2601287&_dad=portal&_schema=PORTAL>)."
+        },
+        "gkz_sa" : {
+          "type" : "integer",
+          "format" : "int64",
+          "example" : 90601,
+          "description" : "Community ID (Gemeindekennzahl, see <http://www.statistik.at/web_de/klassifikationen/regionale_gliederungen/gemeinden/index.html>)"
+        },
+        "land_cover" : {
+          "type" : "integer",
+          "format" : "int64",
+          "example" : 112,
+          "description" : "Classification of the land cover within austria, see <http://www.umweltbundesamt.at/fileadmin/site/umweltthemen/raumplanung/1_flaechennutzung/corine/CORINE_Nomenklatur.pdf> and <https://www.eea.europa.eu/data-and-maps/data/clc-2006-vector-4>"
+        },
+        "locality" : {
+          "type" : "string",
+          "example" : "Mariahilf",
+          "description" : "Name of the cadastral community, see: <http://www.bev.gv.at/portal/page?_pageid=713,2601287&_dad=portal&_schema=PORTAL>"
+        },
+        "community" : {
+          "type" : "string",
+          "example" : "Wien",
+          "description" : "Name of Austrian community (Gemeinde)."
+        },
+        "district" : {
+          "type" : "string",
+          "example" : "Mistelbach",
+          "description" : "Name of Austrian district (Bezirk)."
+        },
+        "province" : {
+          "type" : "string",
+          "example" : "Wien",
+          "description" : "Name of Austrian province (Bundesland)"
+        },
+        "lte_rsrq" : {
+          "type" : "number",
+          "format" : "double",
+          "example" : -6.0,
+          "description" : "LTE signal quality in decibels"
+        },
+        "server_name" : {
+          "type" : "string",
+          "example" : "RTR-DEVELOP-SERVER",
+          "description" : "Name of the test-server."
+        },
+        "implausible" : {
+          "type" : "boolean",
+          "example" : true,
+          "description" : "Identification of implausible test results."
+        },
+        "pinned" : {
+          "type" : "boolean",
+          "description" : "_True_, if if the test is relevant for generating the statistics (e.g. not part of a series)"
+        },
+        "test_duration" : {
+          "type" : "integer",
+          "format" : "int64",
+          "example" : 7,
+          "description" : "Duration of the test per direction (up- or download) in seconds."
+        },
+        "num_threads_requested" : {
+          "type" : "integer",
+          "format" : "int64",
+          "example" : 3,
+          "description" : "Number of threads requested by the server."
+        },
+        "num_threads" : {
+          "type" : "integer",
+          "format" : "int64",
+          "example" : 3,
+          "description" : "Number of threads used for the downlink test."
+        },
+        "num_threads_ul" : {
+          "type" : "integer",
+          "format" : "int64",
+          "example" : 3,
+          "description" : "Number of threads used for the uplink test."
+        },
+        "model_native" : {
+          "type" : "string",
+          "example" : "SGP321",
+          "description" : "Name of the device used, raw device name."
+        },
+        "product" : {
+          "type" : "string",
+          "example" : "SGP321",
+          "description" : "Name of the client device."
+        },
+        "client_version" : {
+          "type" : "string",
+          "example" : "1.1",
+          "description" : "Software version number of the client."
+        },
+        "network_mcc_mnc" : {
+          "type" : "string",
+          "example" : "232-05",
+          "description" : "Network identification whereas the first three digits represent the country, the digits following the dash represent the mobile network provider within that country."
+        },
+        "network_country" : {
+          "type" : "integer",
+          "format" : "int64",
+          "example" : "DE",
+          "description" : "Country of the network in ISO 3166."
+        },
+        "roaming_type" : {
+          "type" : "integer",
+          "format" : "int64",
+          "example" : 1,
+          "description" : "Integer representing the roaming status of the client:\n* 0: no roaming,\n* 1: national roaming,\n* 2: international roaming.",
+          "enum" : [ 0, 1, 2 ]
+        },
+        "network_name" : {
+          "type" : "string",
+          "example" : "3 AT",
+          "description" : "Display name of the mobile network."
+        },
+        "sim_mcc_mnc" : {
+          "type" : "string",
+          "example" : "232-01",
+          "description" : "Network identification of the SIM provider. The digits of MCC and MNC have the same meaning as described in “network_mcc_mnc”."
+        },
+        "sim_country" : {
+          "type" : "string",
+          "example" : "AT",
+          "description" : "Home country of the SIM card in ISO 3166."
+        },
+        "connection" : {
+          "type" : "string",
+          "example" : "nat_local_to_public_ipv4",
+          "description" : "Type of connection in terms of NAT and IP-Version (e.g. behind NAT with local to public IP and IPv4)."
+        },
+        "asn" : {
+          "type" : "integer",
+          "format" : "int64",
+          "example" : 6830,
+          "description" : "Autonomous system number."
+        },
+        "ip_anonym" : {
+          "type" : "string",
+          "example" : "80.108.108",
+          "description" : "The anonymized IP-Address of the client."
+        },
+        "ndt_download_kbit" : {
+          "type" : "number",
+          "format" : "double",
+          "example" : 1443.0,
+          "description" : "Download speed in the NDT-test in kilobit per second."
+        },
+        "ndt_upload_kbit" : {
+          "type" : "number",
+          "format" : "double",
+          "example" : 2334.0,
+          "description" : "Upload speed in the NDT-test in kilobit per second."
+        },
+        "country_geoip" : {
+          "type" : "string",
+          "example" : "HU",
+          "description" : "Country according client IP address."
+        },
+        "country_asn" : {
+          "type" : "string",
+          "example" : "FI",
+          "description" : "Country of AS of client IP."
+        },
+        "country_location" : {
+          "type" : "string",
+          "example" : "FR",
+          "description" : "Country of geo-location."
+        },
+        "bytes_download" : {
+          "type" : "integer",
+          "format" : "int64",
+          "example" : 13653343,
+          "description" : "Total number of bytes downloaded during download test (excluding training-phase)."
+        },
+        "bytes_upload" : {
+          "type" : "integer",
+          "format" : "int64",
+          "example" : 3712431,
+          "description" : "Total number of bytes uploaded during upload test (excluding training-phase)."
+        },
+        "test_if_bytes_download" : {
+          "type" : "integer",
+          "format" : "int64",
+          "example" : 4991145,
+          "description" : "Data volume received on the interface during the test (including training phase)."
+        },
+        "test_if_bytes_upload" : {
+          "type" : "integer",
+          "format" : "int64",
+          "example" : 1961967,
+          "description" : "Data volume transmitted on the interface during the test (including training phase)."
+        },
+        "testdl_if_bytes_download" : {
+          "type" : "integer",
+          "format" : "int64",
+          "example" : 4580781,
+          "description" : "Data volume received on the interface during the download test."
+        },
+        "testdl_if_bytes_upload" : {
+          "type" : "integer",
+          "format" : "int64",
+          "example" : 107077,
+          "description" : "Data volume transmitted on the interface during the download test."
+        },
+        "testul_if_bytes_download" : {
+          "type" : "integer",
+          "format" : "int64",
+          "example" : 57372,
+          "description" : "Data volume received on the interface during the upload test."
+        },
+        "testul_if_bytes_upload" : {
+          "type" : "integer",
+          "format" : "int64",
+          "example" : 1627790,
+          "description" : "Data volume transmitted on the interface during the upload test."
+        },
+        "duration_download_ms" : {
+          "type" : "number",
+          "format" : "double",
+          "example" : 7000.13,
+          "description" : "Duration of download test in ms."
+        },
+        "duration_upload_ms" : {
+          "type" : "number",
+          "format" : "double",
+          "example" : 7000.11,
+          "description" : "Duration of upload test in ms."
+        },
+        "time_dl_ms" : {
+          "type" : "number",
+          "format" : "double",
+          "example" : 3692.15,
+          "description" : "Relative start time of download in ms."
+        },
+        "time_ul_ms" : {
+          "type" : "number",
+          "format" : "double",
+          "example" : 13496.54,
+          "description" : "Relative start time of upload in ms."
+        },
+        "channel_number" : {
+          "type" : "integer",
+          "format" : "int64",
+          "example" : 397,
+          "description" : "Channel number of the radio channel used during a measurement. E.g. the 18-bit Absolute RF Channel Number (EARFCN) in case of 4G or the 16-bit UMTS Absolute RF Channel Number (UARFCN) in case of 3G."
+        },
+        "radio_band" : {
+          "type" : "integer",
+          "format" : "int64",
+          "example" : 20,
+          "description" : "Radio band used when conducting the test."
+        },
+        "cell_area_code" : {
+          "type" : "integer",
+          "format" : "int64",
+          "example" : 10156,
+          "description" : "Number describing the coarse location of a cell. E.g. the Tracking Area Code (TAC) in case of 4G or the Location Area Code (LAC) in case of 2G or 3G"
+        },
+        "cell_location_id" : {
+          "type" : "integer",
+          "format" : "int64",
+          "example" : 28708964,
+          "description" : "Number identifying the location of a cell. E.g. the 28-bit Cell Identity (CI) in case of 4G, the 28-bit UMTS Cell Identity (CID) in case of UMTS or the 16-bit GSM Cell Identity (CID) in case of GSM."
+        },
+        "signal_classification" : {
+          "type" : "integer",
+          "format" : "int32",
+          "example" : 2,
+          "description" : "Classification for the signal strength in a traffic-light system."
+        },
+        "wifi_link_speed" : {
+          "type" : "number",
+          "format" : "double",
+          "example" : 7562.0,
+          "description" : "WLAN link speed according to the Android API."
+        },
+        "speed_curve" : {
+          "description" : "Aggregated history of transferred data bytes during a test.",
+          "$ref" : "#/definitions/OpenTestGraphDTO"
+        },
+        "speed_curve_threadwise" : {
+          "type" : "object",
+          "description" : "History of transferred data bytes per thread during a test. Returned only if verbose>0.",
+          "additionalProperties" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/definitions/SpeedItemThreadwise"
+              }
+            }
+          }
+        }
+      }
+    },
+    "OpenTestExportDTO" : {
+      "type" : "object",
+      "properties" : {
+        "open_uuid" : {
+          "type" : "string",
+          "example" : "P9f2b7bb1-39ea-454e-aa97-538564d7f8f1",
+          "description" : "Open UUID identifying a test"
+        },
+        "open_test_uuid" : {
+          "type" : "string",
+          "example" : "Oa1f286be-3c91-4f7d-b3d3-29d0e143e20d",
+          "description" : "Open UUID identifying a user"
+        },
+        "time_utc" : {
+          "type" : "string",
+          "example" : "2018-07-15 01:55"
+        },
+        "cat_technology" : {
+          "$ref" : "#/definitions/OpenTestDetailsDTO/properties/cat_technology"
+        },
+        "network_type" : {
+          "$ref" : "#/definitions/OpenTestDetailsDTO/properties/network_type"
+        },
+        "lat" : {
+          "type" : "number",
+          "format" : "double",
+          "example" : 48.2029024,
+          "description" : "Latitude of the client position."
+        },
+        "long" : {
+          "type" : "number",
+          "format" : "double",
+          "example" : 16.3967841,
+          "description" : "Longitude of the client position."
+        },
+        "loc_src" : {
+          "$ref" : "#/definitions/OpenTestDetailsDTO/properties/loc_src"
+        },
+        "loc_accuracy" : {
+          "type" : "number",
+          "format" : "double",
+          "example" : 15.28,
+          "description" : "Estimation of accuracy of client location in meters"
+        },
+        "gkz" : {
+          "$ref" : "#/definitions/OpenTestDetailsDTO/properties/gkz"
+        },
+        "zip_code" : {
+          "$ref" : "#/definitions/OpenTestDetailsDTO/properties/zip_code"
+        },
+        "country_location" : {
+          "$ref" : "#/definitions/OpenTestDetailsDTO/properties/country_location"
+        },
+        "download_kbit" : {
+          "type" : "integer",
+          "format" : "int64",
+          "example" : 6903,
+          "description" : "Download speed in kilobit per second"
+        },
+        "upload_kbit" : {
+          "type" : "integer",
+          "format" : "int64",
+          "example" : 1565,
+          "description" : "Upload speed in kilobit per second"
+        },
+        "ping_ms" : {
+          "type" : "number",
+          "format" : "double",
+          "example" : 16.178334,
+          "description" : "Median ping (round-trip time) in milliseconds, measured on the server side. In previous versions (before June 3rd 2015) this was the minimum ping measured on the client side."
+        },
+        "lte_rsrp" : {
+          "type" : "integer",
+          "format" : "int32",
+          "example" : -81,
+          "description" : "LTE signal strength in dBm."
+        },
+        "lte_rsrq" : {
+          "$ref" : "#/definitions/OpenTestDetailsDTO/properties/lte_rsrq"
+        },
+        "server_name" : {
+          "$ref" : "#/definitions/OpenTestDetailsDTO/properties/server_name"
+        },
+        "test_duration" : {
+          "$ref" : "#/definitions/OpenTestDetailsDTO/properties/test_duration"
+        },
+        "num_threads" : {
+          "$ref" : "#/definitions/OpenTestDetailsDTO/properties/num_threads"
+        },
+        "platform" : {
+          "type" : "string",
+          "example" : "RMBTws",
+          "description" : "Platform on which the test has been conducted. E.g.\n* “Android” (= Google Android App),\n* “iOS” (= Apple iOs App),\n* Applet (= Java applet test within a browser),\n* RMBTjs (= simple JavaScript test within a browser, without Java),\n* RMBTws (= advanced JavaScript test using WebSockets within the browser).\n"
+        },
+        "model" : {
+          "type" : "string",
+          "example" : "Sony Xperia Tablet Z LTE",
+          "description" : "Name of the device used."
+        },
+        "client_version" : {
+          "$ref" : "#/definitions/OpenTestDetailsDTO/properties/client_version"
+        },
+        "network_mcc_mnc" : {
+          "$ref" : "#/definitions/OpenTestDetailsDTO/properties/network_mcc_mnc"
+        },
+        "network_name" : {
+          "$ref" : "#/definitions/OpenTestDetailsDTO/properties/network_name"
+        },
+        "sim_mcc_mnc" : {
+          "$ref" : "#/definitions/OpenTestDetailsDTO/properties/sim_mcc_mnc"
+        },
+        "nat_type" : {
+          "$ref" : "#/definitions/OpenTestDetailsDTO/properties/connection"
+        },
+        "asn" : {
+          "$ref" : "#/definitions/OpenTestDetailsDTO/properties/asn"
+        },
+        "ip_anonym" : {
+          "$ref" : "#/definitions/OpenTestDetailsDTO/properties/ip_anonym"
+        },
+        "ndt_download_kbit" : {
+          "$ref" : "#/definitions/OpenTestDetailsDTO/properties/ndt_download_kbit"
+        },
+        "ndt_upload_kbit" : {
+          "$ref" : "#/definitions/OpenTestDetailsDTO/properties/ndt_upload_kbit"
+        },
+        "implausible" : {
+          "$ref" : "#/definitions/OpenTestDetailsDTO/properties/implausible"
+        },
+        "signal_strength" : {
+          "type" : "integer",
+          "format" : "int32",
+          "example" : -56,
+          "description" : "Signal strength (RSSI) in dBm."
+        },
+        "pinned" : {
+          "$ref" : "#/definitions/OpenTestDetailsDTO/properties/pinned"
+        },
+        "kg_nr" : {
+          "$ref" : "#/definitions/OpenTestDetailsDTO/properties/kg_nr"
+        },
+        "gkz_sa" : {
+          "$ref" : "#/definitions/OpenTestDetailsDTO/properties/gkz_sa"
+        },
+        "land_cover" : {
+          "$ref" : "#/definitions/OpenTestDetailsDTO/properties/land_cover"
+        },
+        "cell_area_code" : {
+          "$ref" : "#/definitions/OpenTestDetailsDTO/properties/cell_area_code"
+        },
+        "cell_location_id" : {
+          "$ref" : "#/definitions/OpenTestDetailsDTO/properties/cell_location_id"
+        },
+        "channel_number" : {
+          "$ref" : "#/definitions/OpenTestDetailsDTO/properties/channel_number"
+        },
+        "radio_band" : {
+          "$ref" : "#/definitions/OpenTestDetailsDTO/properties/radio_band"
+        }
+      }
+    },
+    "OpenTestGraphDTO" : {
+      "type" : "object",
+      "properties" : {
+        "download" : {
+          "type" : "array",
+          "description" : "Measurements of downloaded bytes at various times during the test.",
+          "items" : {
+            "$ref" : "#/definitions/SpeedGraphItemDTO"
+          }
+        },
+        "upload" : {
+          "type" : "array",
+          "description" : "Measurements of uploaded bytes at various times during the test.",
+          "items" : {
+            "$ref" : "#/definitions/SpeedGraphItemDTO"
+          }
+        },
+        "ping" : {
+          "type" : "array",
+          "description" : "The client’s pings throughout the test",
+          "items" : {
+            "$ref" : "#/definitions/PingGraphItemDTO"
+          }
+        },
+        "signal" : {
+          "type" : "array",
+          "description" : "Measurements of signal strength and network type at various times during the test.",
+          "items" : {
+            "$ref" : "#/definitions/SignalGraphItemDTO"
+          }
+        },
+        "location" : {
+          "type" : "array",
+          "description" : "The client’s locations throughout the test.",
+          "items" : {
+            "$ref" : "#/definitions/LocationGraphItem"
+          }
+        }
+      }
+    },
+    "OpenTestSearchDTO" : {
+      "type" : "object",
+      "properties" : {
+        "next_cursor" : {
+          "type" : "integer",
+          "format" : "int64",
+          "example" : 866505,
+          "description" : "cursor for next page"
+        },
+        "duration_ms" : {
+          "type" : "integer",
+          "format" : "int64",
+          "example" : 234,
+          "description" : "duration of the search request in milliseconds"
+        },
+        "error" : {
+          "type" : "string",
+          "description" : "Error while conducting the search"
+        },
+        "results" : {
+          "type" : "array",
+          "description" : "test results matching the criteria",
+          "items" : {
+            "$ref" : "#/definitions/OpenTestDTO"
+          }
+        },
+        "invalid_fields" : {
+          "type" : "array",
+          "example" : "[\"download_kbit\"]",
+          "description" : "Invalid fields in the search request",
+          "items" : {
+            "type" : "string"
+          }
+        }
+      }
+    },
+    "PingGraphItemDTO" : {
+      "type" : "object",
+      "properties" : {
+        "ping_ms" : {
+          "type" : "number",
+          "format" : "double",
+          "example" : 8.0,
+          "description" : "Ping (round-trip time) in milliseconds, measured on the server side."
+        },
+        "time_elapsed" : {
+          "type" : "integer",
+          "format" : "int64",
+          "example" : 55,
+          "description" : "The time elapsed since the start of the test in milliseconds."
+        }
+      }
+    },
+    "SignalGraphItemDTO" : {
+      "type" : "object",
+      "properties" : {
+        "time_elapsed" : {
+          "type" : "integer",
+          "format" : "int64",
+          "example" : 55,
+          "description" : "The time elapsed since the start of the test in milliseconds."
+        },
+        "network_type" : {
+          "type" : "string",
+          "example" : "LTE",
+          "description" : "Type of the network, e.g. GSM, EDGE, UMTS, HSPA, LTE, LAN, WLAN…"
+        },
+        "signal_strength" : {
+          "type" : "integer",
+          "format" : "int32",
+          "example" : -85,
+          "description" : "Signal strength (RSSI) in dBm."
+        },
+        "lte_rsrp" : {
+          "type" : "integer",
+          "format" : "int32",
+          "example" : -77,
+          "description" : "LTE signal strength in dBm."
+        },
+        "lte_rsrq" : {
+          "type" : "integer",
+          "format" : "int32",
+          "example" : -6,
+          "description" : "LTE signal quality in decibels."
+        },
+        "cat_technology" : {
+          "type" : "string",
+          "example" : "3G",
+          "description" : "Technology category of the network, e.g. “3G”, “4G”, “WLAN”."
+        },
+        "cell_info_2G" : {
+          "description" : "Additional information about the used 2G radio cell",
+          "$ref" : "#/definitions/CellInfo2G"
+        },
+        "cell_info_3G" : {
+          "description" : "Additional information about the used 3G radio cell",
+          "$ref" : "#/definitions/CellInfo3G"
+        },
+        "cell_info_4G" : {
+          "description" : "Additional information about the used 4G radio cell",
+          "$ref" : "#/definitions/CellInfo4G"
+        }
+      }
+    },
+    "SpeedGraphItemDTO" : {
+      "type" : "object",
+      "properties" : {
+        "bytes_total" : {
+          "type" : "number",
+          "format" : "double",
+          "example" : 4096.0,
+          "description" : "The sum of all bytes transferred since the start of the test phase."
+        },
+        "time_elapsed" : {
+          "type" : "integer",
+          "format" : "int64",
+          "example" : 55,
+          "description" : "The time elapsed since the start of the test phase in milliseconds."
+        }
+      }
+    },
+    "SpeedItemThreadwise" : {
+      "type" : "object",
+      "properties" : {
+        "bytes_total" : {
+          "type" : "number",
+          "format" : "double",
+          "example" : 4096.0,
+          "description" : "The sum of all bytes transferred since the start of the test phase."
+        },
+        "time_elapsed_ns" : {
+          "type" : "integer",
+          "format" : "int64",
+          "example" : 41183662,
+          "description" : "The time elapsed since the start of the test phase for this thread, in nanoseconds."
+        }
+      }
+    }
+  }
+}

--- a/RMBTStatisticServer/src/at/rtr/rmbt/statisticServer/OpenTestResource.java
+++ b/RMBTStatisticServer/src/at/rtr/rmbt/statisticServer/OpenTestResource.java
@@ -17,18 +17,18 @@
 package at.rtr.rmbt.statisticServer;
 
 import java.sql.*;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
+import at.rtr.rmbt.statisticServer.opendata.dto.*;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import org.apache.commons.dbutils.BasicRowProcessor;
+import org.apache.commons.dbutils.GenerousBeanProcessor;
+import org.apache.commons.dbutils.handlers.BeanHandler;
+import org.apache.commons.dbutils.handlers.BeanListHandler;
 import org.restlet.data.Form;
 import org.restlet.data.Status;
 import org.restlet.resource.Get;
@@ -38,7 +38,6 @@ import at.rtr.rmbt.shared.model.SpeedItems;
 import at.rtr.rmbt.shared.model.SpeedItems.SpeedItem;
 import at.rtr.rmbt.shared.smoothing.Smoothable;
 import at.rtr.rmbt.shared.smoothing.SmoothingFunction;
-import at.rtr.rmbt.util.BandCalculationUtil;
 
 import com.google.gson.Gson;
 
@@ -60,94 +59,9 @@ public class OpenTestResource extends ServerResource
      */
     public final static int SMOOTHING_DATA_AMOUNT = 5;
 
-    //all fields that should be displayed in a detailed request
-    private final String[] openDataFieldsFull = {
-    		"open_uuid", //csv 1
-    		"open_test_uuid", //csv 2
-    		"time", //csv 3
-    		"cat_technology",  //csv 4
-    		"network_type", //csv 5
-    		"lat", //csv 6
-    		"long", //csv 7
-    		"loc_src", //csv 8
-    		"loc_accuracy",
-    		"public_ip_as_name",
-            "zip_code",
-            "kg_nr",
-            "gkz",
-            "gkz_sa",
-            "land_cover",
-            "locality",
-            "community",
-            "district",
-            "province",
-            "download_kbit", //csv 10
-            "upload_kbit", //csv 11
-            "wifi_link_speed",
-            "ping_ms", //csv 12
-            "signal_strength", //csv 13
-            "lte_rsrp", //csv 29
-            "lte_rsrq",
-            "server_name", //csv 14
-            "implausible", //csv 28
-            "pinned",
-            "test_duration", //csv 15
-            "num_threads_requested",
-            "num_threads", //csv 16
-            "num_threads_ul",
-            "platform", //csv 17
-            "model", //csv 18
-            "model_native",
-            "product",
-            "client_version",  //csv 19
-            "network_mcc_mnc", //csv 20
-            "network_country",
-            "roaming_type",
-            "network_name", //csv 21
-            "sim_mcc_mnc", //csv 22           
-            "sim_country",
-            "provider_name",
-            "connection", //csv 23
-            "asn", //csv 24
-            "ip_anonym", //csv 25
-            "ndt_download_kbit", //csv 26
-            "ndt_upload_kbit", //csv 27
-            "country_geoip",
-            "country_location",
-            "country_asn",
-            "bytes_download",
-            "bytes_upload",
-            "test_if_bytes_download",
-            "test_if_bytes_upload",
-            "testdl_if_bytes_download",
-            "testdl_if_bytes_upload",
-            "testul_if_bytes_download",
-            "testul_if_bytes_upload",
-            "duration_download_ms",
-            "duration_upload_ms",
-            "time_dl_ms",
-            "time_ul_ms",
-            "channel_number",
-            "radio_band",
-            "cell_area_code",
-            "cell_location_id"
-    };
-
-    //all fields that are numbers (and are formatted as numbers in json)
-    private final HashSet<String> openDataNumberFields = new HashSet<>(Arrays.asList(new String[]{"time", "lat", "long", "loc_accuracy",
-        "zip_code", "kg_nr", "gkz","gkz_sa","land_cover","download_kbit",
-        "upload_kbit","ping_ms","signal_strength","lte_rsrp","lte_rsrq","test_duration","num_threads","ndt_download_kbit","ndt_upload_kbit","asn",
-        "bytes_download","bytes_upload","test_if_bytes_download","test_if_bytes_upload","testdl_if_bytes_download",
-        "testdl_if_bytes_upload","testul_if_bytes_download","testul_if_bytes_upload","duration_download_ms","duration_upload_ms","time_dl_ms",
-        "time_ul_ms", "roaming_type", "num_threads_ul", "num_threads_requested", "channel_number", "radio_band", "cell_area_code", "cell_location_id"
-        }));
-
-    //all fields that are boolean
-    private final HashSet<String> openDataBooleanFields = new HashSet<>(Arrays.asList(new String[] {"implausible", "pinned"}));
 
     @Get("json")
-    public String request(final String entity)
-    {
+    public String request(final String entity) {
         int verboseLevel = 0;
         addAllowOrigin();
 
@@ -155,27 +69,24 @@ public class OpenTestResource extends ServerResource
         String openUUID = getRequest().getAttributes().get("open_test_uuid").toString();
 
 
-
         final Form getParameters = getRequest().getResourceRef().getQueryAsForm();
         //allow sender + verbose
         for (String name : getParameters.getNames()) {
-        	if (name.equals("verbose")) {
-        		try {
+            if (name.equals("verbose")) {
+                try {
                     verboseLevel = Integer.parseInt(getParameters.getFirstValue("verbose"));
-                }
-                catch (NumberFormatException ex) {
+                } catch (NumberFormatException ex) {
                     Logger.getGlobal().info("invalid non-numberic verbosity level");
                 }
-        	}
-        	else if (name.equals("sender") || name.equals("?sender")) { //allow for ?sender; used by some users due to error in old documentation
-        		//ignore for now
-        		final String sender_id;
-        		if (name.equals("sender"))
-        			sender_id = "sender " + getParameters.getFirstValue("sender");
-        		else
-        			sender_id = "sender " + getParameters.getFirstValue("?sender");
+            } else if (name.equals("sender") || name.equals("?sender")) { //allow for ?sender; used by some users due to error in old documentation
+                //ignore for now
+                final String sender_id;
+                if (name.equals("sender"))
+                    sender_id = "sender " + getParameters.getFirstValue("sender");
+                else
+                    sender_id = "sender " + getParameters.getFirstValue("?sender");
 //        		System.out.println(sender_id);
-        		//the logging block would require write access to the database
+                //the logging block would require write access to the database
         		/*
         		final String sql = "UPDATE json_sender SET count = count + 1 WHERE sender_id = ?";
         		PreparedStatement ps = null;
@@ -190,11 +101,21 @@ public class OpenTestResource extends ServerResource
                     Logger.getLogger(OpenTestResource.class.getName()).log(Level.SEVERE, null, e);
                 }
                 */
-        	}
+            }
         }
 
-        return getSingleOpenTest(openUUID, verboseLevel);
+        OpenTestDetailsDTO ret = getSingleOpenTest(openUUID, verboseLevel);
+        ObjectMapper om = new ObjectMapper();
+        om.setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE);
+        String sr = null;
+        try {
+            sr = om.writer().writeValueAsString(ret);
+        } catch (JsonProcessingException e) {
+            e.printStackTrace();
+            setStatus(Status.SERVER_ERROR_INTERNAL);
+        }
 
+        return sr;
     }
 
     /**
@@ -353,7 +274,7 @@ public class OpenTestResource extends ServerResource
      *
      */
 
-    private String getSingleOpenTest(String openTestUUID, int verboseLevel) {
+    private OpenTestDetailsDTO getSingleOpenTest(String openTestUUID, int verboseLevel) {
         final String sql = "SELECT t.uid as test_uid, " +
                 " ('P' || t.open_uuid) open_uuid," +  //csv 1:open_uuid, UUID prefixed with 'P'
                 " ('O' || t.open_test_uuid) open_test_uuid," + //csv  open_test_uuid, UUID prefixed with 'O'
@@ -374,14 +295,14 @@ public class OpenTestResource extends ServerResource
                 " WHEN (t.geo_accuracy < ?) THEN" +
                 " ROUND(t.geo_lat*1111)/1111" + // approx 100m
                 " ELSE null" +
-                " END) lat," +
+                " END) latitude," +
                 // csv 7:long
                 " (CASE WHEN (t.geo_accuracy < ?) AND (t.geo_provider IS DISTINCT FROM 'manual') AND (t.geo_provider IS DISTINCT FROM 'geocoder') THEN" +
                 " t.geo_long" +
                 " WHEN (t.geo_accuracy < ?) THEN" +
                 " ROUND(t.geo_long*741)/741 " + //approx 100m
                 " ELSE null" +
-                " END) long," +
+                " END) longitude," +
                 // csv 8:loc_src android: 'gps'/'network'; browser/iOS: '' (empty string)
                 " (CASE WHEN ((t.geo_provider = 'manual') OR (t.geo_provider = 'geocoder')) THEN" +
                 " 'rastered'" + //make raster transparent
@@ -474,12 +395,12 @@ public class OpenTestResource extends ServerResource
 
         //System.out.println(sql);
 
+        OpenTestDetailsDTO dto = new OpenTestDetailsDTO();
 
         final String[] columns;
         PreparedStatement ps = null;
         ResultSet rs = null;
 
-        final JSONObject response = new JSONObject();
         try
         {
             ps = conn.prepareStatement(sql);
@@ -504,88 +425,40 @@ public class OpenTestResource extends ServerResource
                 return null;
             rs = ps.getResultSet();
 
+            BeanHandler<OpenTestDetailsDTO> handler = new BeanHandler<>(OpenTestDetailsDTO.class,new BasicRowProcessor(new GenerousBeanProcessor()));
+            dto = handler.handle(rs);
 
-            if (rs.next())
+            if (dto != null)
             {
-                //fetch data for every field
-                for (int i=0;i<openDataFieldsFull.length;i++) {
-
-                    //convert data to correct json response
-                    final Object obj = rs.getObject(openDataFieldsFull[i]);
-                    if (openDataBooleanFields.contains(openDataFieldsFull[i])) {
-                    	if (obj == null) {
-                    		response.put(openDataFieldsFull[i], false);
-                    	}
-                    	else {
-                    		response.put(openDataFieldsFull[i], obj);
-                    	}
-                    }
-                    else if (obj==null) {
-                        response.put(openDataFieldsFull[i], JSONObject.NULL);
-                    }
-                    else if (openDataNumberFields.contains(openDataFieldsFull[i])) {
-                    	final String tmp = obj.toString().trim();
-                    	if (tmp.isEmpty())
-                    		response.put(openDataFieldsFull[i], JSONObject.NULL);
-                    	else
-                    		response.put(openDataFieldsFull[i], JSONObject.stringToValue(tmp));
-                    }
-                    else {
-                    	final String tmp = obj.toString().trim();
-						if (tmp.isEmpty())
-							response.put(openDataFieldsFull[i], JSONObject.NULL);
-						else
-							response.put(openDataFieldsFull[i], tmp);
-                    }
-
-                }
-
                 //classify download, upload, ping, signal
-                response.put("download_classification", Classification.classify(Classification.THRESHOLD_DOWNLOAD, rs.getLong("download_kbit"), capabilities.getClassificationCapability().getCount()));
-                response.put("upload_classification", Classification.classify(Classification.THRESHOLD_UPLOAD, rs.getLong("upload_kbit"), capabilities.getClassificationCapability().getCount()));
-                response.put("ping_classification", Classification.classify(Classification.THRESHOLD_PING, rs.getLong("ping_ms")*1000000, capabilities.getClassificationCapability().getCount()));
+                dto.setDownloadClassification(Classification.classify(Classification.THRESHOLD_DOWNLOAD, dto.getDownloadKbit(), capabilities.getClassificationCapability().getCount()));
+                dto.setUploadClassification(Classification.classify(Classification.THRESHOLD_UPLOAD, dto.getUploadKbit(), capabilities.getClassificationCapability().getCount()));
+                dto.setPingClassification(Classification.classify(Classification.THRESHOLD_PING, Math.round(dto.getPingMs() * 1000000), capabilities.getClassificationCapability().getCount()));
+
                 //classify signal accordingly
-				if ((rs.getString("signal_strength") != null || rs
-						.getString("lte_rsrp") != null)
-						&& rs.getString("network_type") != null) { // signal available
-					if (rs.getString("lte_rsrp") == null) { // use RSSI
-						if (rs.getString("network_type").equals("WLAN")) { // RSSI for Wifi
-							response.put(
-									"signal_classification",
-									Classification
-											.classify(
-													Classification.THRESHOLD_SIGNAL_WIFI,
-													rs.getLong("signal_strength"), capabilities.getClassificationCapability().getCount()));
+				if ((dto.getSignalStrength() != null || dto.getLteRsrp() != null)
+						&& dto.getNetworkType() != null) { // signal available
+					if (dto.getLteRsrp() == null) { // use RSSI
+						if (dto.getNetworkType().equals("WLAN")) { // RSSI for Wifi
+                            dto.setSignalClassification(Classification.classify(Classification.THRESHOLD_SIGNAL_WIFI, dto.getSignalStrength(), capabilities.getClassificationCapability().getCount()));
 						} else { // RSSI for Mobile
-							response.put(
-									"signal_classification",
-									Classification
-											.classify(
-													Classification.THRESHOLD_SIGNAL_MOBILE,
-													rs.getLong("signal_strength"), capabilities.getClassificationCapability().getCount()));
+                            dto.setSignalClassification(Classification.classify(Classification.THRESHOLD_SIGNAL_MOBILE, dto.getSignalStrength(), capabilities.getClassificationCapability().getCount()));
 						}
 					} else // RSRP for LTE
-						response.put("signal_classification", Classification
-								.classify(Classification.THRESHOLD_SIGNAL_RSRP,
-										rs.getLong("lte_rsrp"), capabilities.getClassificationCapability().getCount()));
+                        dto.setSignalClassification(Classification.classify(Classification.THRESHOLD_SIGNAL_RSRP,dto.getLteRsrp(), capabilities.getClassificationCapability().getCount()));
 				} else { // no signal available
-					response.put("signal_classification", JSONObject.NULL);
+					dto.setSignalClassification(null);
 				}
 
 
                 //also load download/upload-speed-data, signal data and location data if possible
-                JSONObject speedCurve = new JSONObject();
-                JSONArray pingArray = new JSONArray();
-                JSONArray downloadSpeeds = new JSONArray();
-                JSONArray uploadSpeeds = new JSONArray();
-                JSONArray locArray = new JSONArray();
-                JSONArray signalArray = new JSONArray();
-
-
 
                 // speed data
                 final Gson gson = getGson(false);
                 final SpeedItems speedItems = gson.fromJson(rs.getString("speed_items"), SpeedItems.class);
+
+                //graphs
+                OpenTestGraphDTO graphs = new OpenTestGraphDTO();
 
                 if (speedItems != null)
                 {
@@ -594,27 +467,30 @@ public class OpenTestResource extends ServerResource
                     //System.out.println(uploadList.size());
                     final List<SpeedItem> downloadList = speedItems.getAccumulatedSpeedItemsDownload();
                     //System.out.println(downloadList.size());
+                    List<SpeedGraphItemDTO> downloadSpeeds = new ArrayList<>();
+                    List<SpeedGraphItemDTO> uploadSpeeds = new ArrayList<>();
 
                     if (!RETURN_SMOOTHED_SPEED_CURVES) {
+                        SpeedGraphItemDTO obj;
                         for (SpeedItem item : uploadList) {
-                            JSONObject obj = new JSONObject();
-                            final long time = Math.round((double) item.getTime() / 1000000);
+                            obj = new SpeedGraphItemDTO();
+                            final long time = Math.round((double) item.getTime() / 1e6);
                             if (time == lastTime)
                                 continue;
-                            obj.put("time_elapsed", time);
-                            obj.put("bytes_total", item.getBytes());
-                            uploadSpeeds.put(obj);
+                            obj.setTimeElapsed(item.getTime());
+                            obj.setBytesTotal(item.getBytes());
+                            uploadSpeeds.add(obj);
                             lastTime = time;
                         }
                         lastTime = -1;
                         for (SpeedItem item : downloadList) {
-                            JSONObject obj = new JSONObject();
-                            final long time = Math.round((double) item.getTime() / 1000000);
+                            obj = new SpeedGraphItemDTO();
+                            final long time = Math.round((double) item.getTime() / 1e6);
                             if (time == lastTime)
                                 continue;
-                            obj.put("time_elapsed", time);
-                            obj.put("bytes_total", item.getBytes());
-                            downloadSpeeds.put(obj);
+                            obj.setTimeElapsed(item.getTime());
+                            obj.setBytesTotal(item.getBytes());
+                            downloadSpeeds.add(obj);
                             lastTime = time;
                         }
                     }
@@ -623,121 +499,97 @@ public class OpenTestResource extends ServerResource
                         final List<? extends Smoothable> smoothedDownloadList = SmoothingFunction.smooth(SmoothingFunction.CENTRAL_MOVING_AVARAGE, downloadList, SMOOTHING_DATA_AMOUNT);
 
                         lastTime = -1;
-                        final JSONArray smoothedUploadSpeeds = new JSONArray();
+
+                        SpeedGraphItemDTO obj;
                         for (Smoothable item : smoothedUploadList) {
-                            JSONObject obj = new JSONObject();
+                            obj = new SpeedGraphItemDTO();
                             final long time = Math.round((double) item.getXValue() / 1000000);
                             if (time == lastTime)
                                 continue;
-                            obj.put("time_elapsed", time);
-                            obj.put("bytes_total", item.getYValue());
-                            smoothedUploadSpeeds.put(obj);
-                            lastTime = time;
+                            obj.setTimeElapsed(time);
+                            obj.setBytesTotal(item.getYValue());
+                            uploadSpeeds.add(obj);
                         }
 
                         lastTime = -1;
-                        final JSONArray smoothedDownloadSpeeds = new JSONArray();
+
                         for (Smoothable item : smoothedDownloadList) {
-                            JSONObject obj = new JSONObject();
-                            final long time = Math.round((double) item.getXValue() / 1000000);
+                            obj = new SpeedGraphItemDTO();
+                            final long time = Math.round((double) item.getXValue() / 1e6);
                             if (time == lastTime)
                                 continue;
-                            obj.put("time_elapsed", time);
-                            obj.put("bytes_total", item.getYValue());
-                            smoothedDownloadSpeeds.put(obj);
-                            lastTime = time;
+                            obj.setTimeElapsed(time);
+                            obj.setBytesTotal(item.getYValue());
+                            downloadSpeeds.add(obj);
                         }
-
-                        downloadSpeeds = smoothedDownloadSpeeds;
-                        uploadSpeeds = smoothedUploadSpeeds;
                     }
+
+                    graphs.setDownload(downloadSpeeds);
+                    graphs.setUpload(uploadSpeeds);
                 }
 
                 //if verbose - also add raw json data
                 if (speedItems != null && verboseLevel > 0) {
                     Map<String, Map<Integer, List<SpeedItem>>> rawJSON = speedItems.getRawJSONData();
-                    JSONObject obj = new JSONObject();
+
+                    //threads
+                    Map<String, Map<String, List<SpeedGraphItemDTO.SpeedItemThreadwise>>> threadwise = new HashMap<>();
+
                     //phases
                     for (String phase : rawJSON.keySet()) {
-                        //threads
-                        JSONObject threads = new JSONObject();
-                        obj.put(phase, threads);
+
+                        Map<String, List<SpeedGraphItemDTO.SpeedItemThreadwise>> threads = new HashMap<>();
+                        threadwise.put(phase, threads);
 
                         for (int thread : rawJSON.get(phase).keySet()) {
-                            JSONArray threadItems = new JSONArray();
-                            threads.put(Integer.toString(thread),threadItems);
+                            List<SpeedGraphItemDTO.SpeedItemThreadwise> threadItems = new ArrayList<>();
+                            threads.put(String.valueOf(thread),threadItems);
 
                             //speed items
                             for (SpeedItem item : rawJSON.get(phase).get(thread)) {
-                                JSONObject measurement = new JSONObject();
-                                measurement.put("time_elapsed_ns", item.getTime());
-                                measurement.put("bytes_total", item.getBytes());
-                                threadItems.put(measurement);
+                                SpeedGraphItemDTO.SpeedItemThreadwise measurement = new SpeedGraphItemDTO.SpeedItemThreadwise();
+                                measurement.setBytesTotal(item.getBytes());
+                                measurement.setTimeElapsed(item.getTime());
+                                threadItems.add(measurement);
                             }
                         }
                     }
-                    response.put("speed_curve_threadwise", obj);
+
+                    dto.setSpeedCurveThreadwise(threadwise);
                 }
 
                 //Ping
-                PingGraph pingGraph = new PingGraph(UUID.fromString(openTestUUID), conn);
-                for (PingGraph.PingGraphItem item : pingGraph.getPingList()) {
-                    pingArray.put(item.toJSON());
-                }
+                List<PingGraphItemDTO> pingGraph = getPingGraph(UUID.fromString(openTestUUID), conn);
+                graphs.setPing(pingGraph);
 
                 //Load signal strength from database
-                SignalGraph sigGraph = new SignalGraph(rs.getLong("test_uid"), UUID.fromString(rs.getObject("open_test_uuid").toString().substring(1)), rs.getTimestamp("client_time").getTime(), conn);
-                for (SignalGraph.SignalGraphItem item : sigGraph.getSignalList()) {
-                	signalArray.put(item.toJSON());
-                }
-
+                List<SignalGraphItemDTO> radioSignalGraph = getRadioSignalGraph(rs.getLong("test_uid"), UUID.fromString(rs.getObject("open_test_uuid").toString().substring(1)), rs.getTimestamp("client_time").getTime(), conn);
+                graphs.setSignal(radioSignalGraph);
 
                 //Load gps coordinates from database
-                LocationGraph locGraph = new LocationGraph(rs.getLong("test_uid"),  rs.getTimestamp("client_time").getTime(), conn);
-                double totalDistance = locGraph.getTotalDistance();
-                for (LocationGraph.LocationGraphItem item : locGraph.getLocations()) {
-                	JSONObject json = new JSONObject();
-                	json.put("time_elapsed",item.getTimeElapsed());
-                	json.put("lat", item.getLatitude());
-                	json.put("long", item.getLongitude());
-                	json.put("loc_accuracy", (item.getAccuracy() > 0) ? item.getAccuracy() : JSONObject.NULL );
-                    json.put("altitude", (item.getAltitude() == null || item.getAltitude() == 0) ? JSONObject.NULL : item.getAltitude());
-                    json.put("loc_src", item.getProvider());
-                    json.put("speed", (item.getSpeed() != null) ? item.getSpeed() : JSONObject.NULL);
-                    json.put("bearing", (item.getBearing() != null) ? item.getBearing() : JSONObject.NULL);
-                	locArray.put(json);
+                LocationGraphDTO locGraph = getLocationGraph(rs.getLong("test_uid"),  rs.getTimestamp("client_time").getTime(), conn);
+                graphs.setLocation(locGraph.getLocations());
+
+                dto.setSpeedCurve(graphs);
+
+
+                //add total distance during test - but only if within bounds
+                if ((locGraph.getTotalDistance() > 0) &&
+                        locGraph.getTotalDistance() <= Double.parseDouble(settings.getString("RMBT_GEO_DISTANCE_DETAIL_LIMIT"))) {
+                    dto.setDistance(locGraph.getTotalDistance());
                 }
 
-
-
-                speedCurve.put("upload", uploadSpeeds);
-                speedCurve.put("download", downloadSpeeds);
-                speedCurve.put("ping", pingArray);
-                speedCurve.put("signal", signalArray);
-                speedCurve.put("location", locArray);
-                response.put("speed_curve", speedCurve);
-                //add total distance during test - but only if within bounds
-                if ((totalDistance > 0) &&
-                        totalDistance <= Double.parseDouble(settings.getString("RMBT_GEO_DISTANCE_DETAIL_LIMIT")))
-                    response.put("distance", totalDistance);
-                else
-                    response.put("distance", JSONObject.NULL);
 
             } else {
                 //invalid open_uuid
                 setStatus(Status.CLIENT_ERROR_NOT_FOUND);
-                response.put("error","invalid open-uuid");
+                dto.setError("invalid open-uuid");
             }
         }
-        catch (final JSONException e) {
-            Logger.getLogger(OpenTestResource.class.getName()).log(Level.SEVERE, null, e);
-        } catch (SQLException ex) {
-            try {
-                setStatus(Status.CLIENT_ERROR_NOT_FOUND);
-                response.put("error","invalid open-uuid");
-            } catch (JSONException ex1) {
-                Logger.getLogger(OpenTestResource.class.getName()).log(Level.SEVERE, null, ex1);
-            }
+        catch (SQLException ex) {
+            setStatus(Status.CLIENT_ERROR_NOT_FOUND);
+            dto.setError("invalid open-uuid");
+
             Logger.getLogger(OpenTestResource.class.getName()).log(Level.SEVERE, null, ex);
         }
         finally
@@ -755,7 +607,7 @@ public class OpenTestResource extends ServerResource
             }
         }
 
-        return response.toString();
+        return dto;
     }
 
     /**
@@ -781,580 +633,169 @@ public class OpenTestResource extends ServerResource
         return dist;
     }
 
-    public static class LocationGraph {
-    	private double totalDistance;
-    	private ArrayList<LocationGraphItem> locations = new ArrayList<>();
+    private LocationGraphDTO getLocationGraph(long testUID, long testTime, java.sql.Connection conn) throws SQLException {
+        PreparedStatement psLocation = conn.prepareStatement("SELECT test_id, g.geo_lat latitude, g.geo_long longitude, g.accuracy loc_accuracy, g.bearing bearing, g.speed speed, g.provider provider, altitude, time "
+                + " FROM geo_location g "
+                + " WHERE g.test_id = ? and accuracy < " + settings.getString("RMBT_GEO_ACCURACY_DETAIL_LIMIT")
+                + " ORDER BY time;");
+        psLocation.setLong(1, testUID);
+        ResultSet rs = psLocation.executeQuery();
 
-    	/**
-    	 * Gets all distinctive locations of a client during a test
-    	 * @param testUID the uid of the test
-    	 * @param testTime the begin of the test
-    	 * @throws SQLException
-    	 */
-    	public LocationGraph(long testUID, long testTime, java.sql.Connection conn) throws SQLException {
-    		PreparedStatement psLocation = conn.prepareStatement("SELECT test_id, g.geo_lat lat, g.geo_long long, g.accuracy loc_accuracy, g.bearing bearing, g.speed speed, g.provider provider, altitude, time "
-            		+ "FROM geo_location g "
-            		+ "WHERE g.test_id = ? and accuracy < " + settings.getString("RMBT_GEO_ACCURACY_DETAIL_LIMIT") + " "
-            		+ "ORDER BY time;");
-            psLocation.setLong(1, testUID);
-            ResultSet rsLocation = psLocation.executeQuery();
+        boolean first = true;
+        LocationGraphDTO.LocationGraphItem firstItem = null;
 
-            boolean first = true;
-            LocationGraphItem firstItem = null;
+        Double lastLat = null;
+        Double lastLong = null;
+        double totalDistance=0;
 
-            Double lastLat = null;
-            Double lastLong = null;
-            Double lastAcc = null;
-            this.totalDistance=0;
-            while (rsLocation.next()) {
-            	long timeElapsed = rsLocation.getTimestamp("time").getTime() - testTime;
+        BeanListHandler<LocationGraphDTO.LocationGraphItem> handler = new BeanListHandler<>(LocationGraphDTO.LocationGraphItem.class, new BasicRowProcessor(new GenerousBeanProcessor()));
+        List<LocationGraphDTO.LocationGraphItem> allResultList = handler.handle(rs);
+        Iterator<LocationGraphDTO.LocationGraphItem> iterator = allResultList.iterator();
+        List<LocationGraphDTO.LocationGraphItem> resultList = new ArrayList<>();
 
-            	Double bearing = rsLocation.getDouble("bearing");
-                if (rsLocation.wasNull()) bearing = null;
-                Double speed = rsLocation.getDouble("speed");
-                if (rsLocation.wasNull()) speed = null;
-                Double altitude = rsLocation.getDouble("altitude");
-                if (rsLocation.wasNull()) altitude = null;
+        while (iterator.hasNext()) {
+            LocationGraphDTO.LocationGraphItem item = iterator.next();
+            long timeElapsed = item.getTime().getTime() - testTime;
+            item.setTimeElapsed(timeElapsed);
 
-                LocationGraphItem item = new LocationGraphItem(Math.max(timeElapsed,0), rsLocation.getDouble("long"), rsLocation.getDouble("lat"),  rsLocation.getDouble("loc_accuracy"), altitude, bearing, speed, rsLocation.getString("provider"));
-            	//there could be measurements taken before a test started
-            	//in this case, only return the last one
-            	if (item != null && timeElapsed < 0) {
-            		lastLat = item.getLatitude();
-    				lastLong = item.getLongitude();
-    				lastAcc = item.getAccuracy();
-    				firstItem = item;
-            	}
-            	//put triplet in the array if it is not the first one
-            	else {
-            	    //first item > 0 - add item previously stored for later consumption
-            	    if (firstItem != null) {
-            	        this.locations.add(firstItem);
-            	        firstItem = null;
-                    }
-
-            		//only put the point in the resulting array, if there is a significant
-            		//distance from the last point
-            		//therefore (difference in m) > (tolerance last point + tolerance new point)
-                    if (lastLat != null && lastLong != null) {
-                        double diff = OpenTestResource.distFrom(lastLat, lastLong, item.getLatitude(), item.getLongitude());
-                        this.totalDistance += diff;
-                    }
-
-                    this.locations.add(item);
-                	lastLat = item.getLatitude();
-        			lastLong = item.getLongitude();
-        			lastAcc = item.getAccuracy();
-            	}
+            //there could be measurements taken before a test started
+            //in this case, only return the last one
+            if (item != null && timeElapsed < 0) {
+                lastLat = item.getLatitude();
+                lastLong = item.getLongitude();
+                item.setTimeElapsed(0);
+                firstItem = item;
             }
-
-            //if no item was with time > 0 - add the last one here
-            if (firstItem != null) {
-                this.locations.add(firstItem);
-            }
-
-            //System.out.println("called w id: " + testUID + ", ct: " + testTime + ", d: " + this.totalDistance + ", " + this.getTotalDistance());
-
-            rsLocation.close();
-            psLocation.close();
-    	}
-
-    	public double getTotalDistance() {
-    		return this.totalDistance;
-    	}
-
-    	public ArrayList<LocationGraphItem> getLocations() {
-    		return this.locations;
-    	}
-
-    	private class LocationGraphItem {
-    		private double longitude;
-    		private double latitude;
-    		private double accuracy;
-    		private long timeElapsed;
-    		private Double bearing;
-    		private Double speed;
-    		private Double altitude;
-            private String provider;
-
-    		public LocationGraphItem(long timeElapsed, double longitude, double latitude, double accuracy, Double altitude, Double bearing, Double speed, String provider) {
-    			this.longitude = longitude;
-    			this.latitude = latitude;
-    			this.timeElapsed = timeElapsed;
-    			this.accuracy = accuracy;
-    			this.bearing = bearing;
-    			this.speed = speed;
-    			this.provider = provider;
-    			this.altitude = altitude;
-    		}
-
-    		/**
-    		 * @return The time elapsed since the begin of the test
-    		 */
-    		public long getTimeElapsed() {
-    			return this.timeElapsed;
-    		}
-
-    		public double getLongitude() {
-    			return this.longitude;
-    		}
-
-    		public double getLatitude() {
-    			return this.latitude;
-    		}
-
-    		/**
-    		 * @return The accuracy of the measurement in meters
-    		 */
-    		public double getAccuracy() {
-    			return this.accuracy;
-    		}
-
-
-            public Double getBearing() {
-    		    if (getProvider().equals("gps")) {
-                    return bearing;
+            //put triplet in the array if it is not the first one
+            else {
+                //first item > 0 - add item previously stored for later consumption
+                if (firstItem != null) {
+                    resultList.add(firstItem);
+                    firstItem = null;
                 }
-                return null;
-            }
 
-            public Double getSpeed() {
-    		    if (getProvider().equals("gps")) {
-    		        return speed;
+                //only put the point in the resulting array, if there is a significant
+                //distance from the last point
+                //therefore (difference in m) > (tolerance last point + tolerance new point)
+                if (lastLat != null && lastLong != null) {
+                    double diff = OpenTestResource.distFrom(lastLat, lastLong, item.getLatitude(), item.getLongitude());
+                    totalDistance += diff;
                 }
-                return null;
-            }
 
-            public String getProvider() {
-                return provider;
-            }
-
-            public Double getAltitude() {
-                return altitude;
+                resultList.add(item);
+                lastLat = item.getLatitude();
+                lastLong = item.getLongitude();
             }
         }
+
+        //if no item was with time > 0 - add the last one here
+        if (firstItem != null) {
+            resultList.add(firstItem);
+        }
+
+        LocationGraphDTO lg = new LocationGraphDTO();
+        lg.setLocations(resultList);
+        lg.setTotalDistance(totalDistance);
+        return lg;
     }
 
-    public static class PingGraph {
-        private ArrayList<PingGraphItem> pingList = new ArrayList<>();
+    private List<PingGraphItemDTO> getPingGraph(UUID openTestUuid, java.sql.Connection conn) throws SQLException {
+        PreparedStatement psPing = conn.prepareStatement("SELECT value_server/1e6 ping_ms, time_ns/1e6 time_elapsed FROM  ping WHERE open_test_uuid = ?");
+        psPing.setObject(1, openTestUuid);
 
-        public PingGraph(UUID openTestUuid, java.sql.Connection conn) throws SQLException {
-            PreparedStatement psPing = conn.prepareStatement("SELECT value_server, time_ns FROM  ping WHERE open_test_uuid = ?");
-            psPing.setObject(1, openTestUuid);
+        BeanListHandler<PingGraphItemDTO> handler = new BeanListHandler<>(PingGraphItemDTO.class,new BasicRowProcessor(new GenerousBeanProcessor()));
+        List<PingGraphItemDTO> pingList = handler.handle(psPing.executeQuery());
 
-            ResultSet rsPing = psPing.executeQuery();
-
-            //if there are no results -> try using the old tables that may be available for some measurements
-            while (rsPing.next()) {
-                double pingMs = rsPing.getLong("value_server");
-                pingMs = pingMs / 1e6; //nanoseconds to milliseconds
-                long timeElapsed = rsPing.getLong("time_ns");
-                timeElapsed = (long) (timeElapsed / 1e6);
-                PingGraphItem item = new PingGraphItem(pingMs, timeElapsed);
-                getPingList().add(item);
-            }
-            psPing.close();
-        }
-
-        public ArrayList<PingGraphItem> getPingList() {
-            return pingList;
-        }
-
-        public static class PingGraphItem {
-            private final double pingMs;
-            private final long timeElapsed;
-
-            public PingGraphItem(double pingMs, long timeElapsed) {
-                this.pingMs = pingMs;
-                this.timeElapsed = timeElapsed;
-            }
-
-
-            public double getPingMs() {
-                return pingMs;
-            }
-
-            public long getTimeElapsed() {
-                return timeElapsed;
-            }
-
-            public JSONObject toJSON() {
-                JSONObject json = new JSONObject();
-                json.put("ping_ms", getPingMs());
-                json.put("time_elapsed", getTimeElapsed());
-                return json;
-            }
-        }
+        return pingList;
     }
 
-    public static class SignalGraph {
-    	private static int LOWER_BOUND = -1500;
-    	private static int MAX_TIME = 60000;
 
-    	private ArrayList<SignalGraphItem> signalList = new ArrayList<>();
+    private static List<SignalGraphItemDTO> getRadioSignalGraph(long testUID, UUID openTestUuid, long testTime, java.sql.Connection conn) throws SQLException {
+        final int LOWER_BOUND = -1500;
+        final int MAX_TIME = 60000;
 
-    	/**
-    	 * Gets all signal measurements from a test
-    	 * @param testUID the test uid
-    	 * @param testTime the begin of the test
-    	 * @throws SQLException
-    	 */
-        public SignalGraph(long testUID, UUID openTestUuid, long testTime, java.sql.Connection conn) throws SQLException {
-            boolean additionalInformation = true;
-            PreparedStatement psSignal = conn.prepareStatement("SELECT radio_cell.open_test_uuid, radio_cell.mnc, radio_cell.mcc, radio_cell.location_id, radio_cell.area_code, " +
-                    "radio_cell.primary_scrambling_code, radio_cell.channel_number, " +
-                    "nt.name network_type, technology cat_technology, signal_strength, lte_rsrp, lte_rsrq, signal_strength wifi_rssi, time " +
-                    "FROM radio_cell " +
-                    "JOIN radio_signal ON radio_signal.cell_uuid = radio_cell.uuid " +
-                    "JOIN network_type nt ON nt.uid = network_type_id " +
-                    "WHERE radio_signal.open_test_uuid = ? " +
-                    "AND radio_cell.active = TRUE " +
-                    "  ORDER BY radio_signal.time;");
-            psSignal.setObject(1, openTestUuid);
+        boolean additionalInformation = true;
+        PreparedStatement psSignal = conn.prepareStatement("SELECT radio_cell.open_test_uuid, radio_cell.mnc, radio_cell.mcc, radio_cell.location_id, radio_cell.area_code, " +
+                "radio_cell.primary_scrambling_code, radio_cell.channel_number, " +
+                "nt.name network_type, technology cat_technology, signal_strength, lte_rsrp, lte_rsrq, signal_strength wifi_rssi, time " +
+                "FROM radio_cell " +
+                "JOIN radio_signal ON radio_signal.cell_uuid = radio_cell.uuid " +
+                "JOIN network_type nt ON nt.uid = network_type_id " +
+                "WHERE radio_signal.open_test_uuid = ? " +
+                "AND radio_cell.active = TRUE " +
+                "  ORDER BY radio_signal.time;");
+        psSignal.setObject(1, openTestUuid);
 
-            ResultSet rsSignal = psSignal.executeQuery();
+        ResultSet rsSignal = psSignal.executeQuery();
 
-            //if there are no results -> try using the old tables that may be available for some measurements
-            if (!rsSignal.isBeforeFirst()) {
-                psSignal.close();
-                additionalInformation = false;
-
-                psSignal = conn.prepareStatement("SELECT test_id, nt.name network_type, nt.group_name cat_technology, signal_strength, lte_rsrp, lte_rsrq, wifi_rssi, time "
-                        + "FROM signal "
-                        + "JOIN network_type nt "
-                        + "ON nt.uid = network_type_id "
-                        + "WHERE test_id = ? "
-                        + "ORDER BY time;");
-                psSignal.setLong(1, testUID);
-
-                rsSignal = psSignal.executeQuery();
-
-            }
-
-            boolean first = true;
-            SignalGraphItem item = null;
-            while (rsSignal.next()) {
-            	long timeElapsed = rsSignal.getTimestamp("time").getTime() - testTime;
-            	//there could be measurements taken before a test started
-            	//in this case, only return the last one
-            	if (first && timeElapsed > 0 && item != null) {
-            		this.signalList.add(item);
-            		first = false;
-            	}
-
-            	//ignore measurements after a threshold of one minute
-            	if (timeElapsed > MAX_TIME)
-            		break;
-
-
-            	Integer signalStrength = rsSignal.getInt("signal_strength");
-            	int lteRsrp = rsSignal.getInt("lte_rsrp");
-            	int lteRsrq = rsSignal.getInt("lte_rsrq");
-            	if (signalStrength == 0) {
-                    signalStrength = rsSignal.getInt("wifi_rssi");
-                }
-
-            	if ((signalStrength != 0 && signalStrength > LOWER_BOUND) || lteRsrp > LOWER_BOUND || lteRsrq > LOWER_BOUND) {
-            	    if (additionalInformation) {
-            	        int channelNumber = rsSignal.getInt("channel_number");
-                        item = new SignalGraphItem(Math.max(timeElapsed, 0), rsSignal.getString("network_type"), signalStrength, lteRsrp, lteRsrq, rsSignal.getString("cat_technology"),
-                                rsSignal.getInt("location_id"), rsSignal.getInt("area_code"), rsSignal.getInt("primary_scrambling_code"), channelNumber);
-                    }
-                    else {
-                        item = new SignalGraphItem(Math.max(timeElapsed, 0), rsSignal.getString("network_type"), signalStrength, lteRsrp, lteRsrq, rsSignal.getString("cat_technology"));
-                    }
-                }
-
-
-            	//put 5-let in the array if it is not the first one
-            	if (!first || rsSignal.isLast()) {
-            		if (timeElapsed < 0) {
-            			item.timeElapsed = 1000;
-            		}
-            		this.signalList.add(item);
-            	}
-            }
-
-            rsSignal.close();
+        //if there are no results -> try using the old tables that may be available for some measurements
+        if (!rsSignal.isBeforeFirst()) {
             psSignal.close();
-    	}
+            additionalInformation = false;
 
-    	public ArrayList<SignalGraphItem>getSignalList() {
-    		return this.signalList;
-    	}
+            psSignal = conn.prepareStatement("SELECT test_id, nt.name network_type, nt.group_name cat_technology, signal_strength, lte_rsrp, lte_rsrq, wifi_rssi, time "
+                    + "FROM signal "
+                    + "JOIN network_type nt "
+                    + "ON nt.uid = network_type_id "
+                    + "WHERE test_id = ? "
+                    + "ORDER BY time;");
+            psSignal.setLong(1, testUID);
 
-    	private static class SignalGraphItem {
-            private long timeElapsed;
-    		private String networkType;
-    		private Integer signalStrength;
-    		private Integer lteRsrp;
-    		private Integer lteRsrq;
-    		private String catTechnology;
-    		private CellInfo2G cellInfo2G;
-    		private CellInfo3G cellInfo3G;
-    		private CellInfo4G cellInfo4G;
+            rsSignal = psSignal.executeQuery();
 
-            public SignalGraphItem(long timeElapsed, String networkType, Integer signalStrength, Integer lteRsrp, Integer lteRsrq, String catTechnology, Integer locationId, Integer areaCode, Integer primaryScramblingCode, Integer channelNumber) {
-                this.timeElapsed = timeElapsed;
-                this.networkType = networkType;
-                signalStrength = (signalStrength == 0) ? null : signalStrength;
-                lteRsrp = (lteRsrp == 0) ? null : lteRsrp;
-                lteRsrq = (lteRsrq == 0) ? null : lteRsrq;
-                locationId = (locationId == 0) ? null : locationId;
-                areaCode = (areaCode == 0) ? null : areaCode;
-                channelNumber = (channelNumber == 0) ? null : channelNumber;
-                primaryScramblingCode = (primaryScramblingCode == 0) ? null : primaryScramblingCode;
+        }
 
-                this.signalStrength = signalStrength;
-                this.lteRsrp = lteRsrp;
-                this.lteRsrq = lteRsrq;
-                this.catTechnology = catTechnology;
+        boolean first = true;
+        SignalGraphItemDTO item = null;
+        List<SignalGraphItemDTO> signalList = new ArrayList<>();
+        while (rsSignal.next()) {
+            long timeElapsed = rsSignal.getTimestamp("time").getTime() - testTime;
+            //there could be measurements taken before a test started
+            //in this case, only return the last one
+            if (first && timeElapsed > 0 && item != null) {
+                signalList.add(item);
+                first = false;
+            }
 
-                switch (catTechnology) {
-                    case "2G":
-                        cellInfo2G = new CellInfo2G(locationId, areaCode, primaryScramblingCode, channelNumber);
-                        break;
-                    case "3G":
-                        cellInfo3G = new CellInfo3G(locationId, areaCode, primaryScramblingCode, channelNumber);
-                        break;
-                    case "4G":
-                        cellInfo4G = new CellInfo4G(locationId, areaCode, primaryScramblingCode, channelNumber);
-                        break;
-                    default:
-                        break;
+            //ignore measurements after a threshold of one minute
+            if (timeElapsed > MAX_TIME)
+                break;
+
+
+            Integer signalStrength = rsSignal.getInt("signal_strength");
+            int lteRsrp = rsSignal.getInt("lte_rsrp");
+            int lteRsrq = rsSignal.getInt("lte_rsrq");
+            if (signalStrength == 0) {
+                signalStrength = rsSignal.getInt("wifi_rssi");
+            }
+
+            if ((signalStrength != 0 && signalStrength > LOWER_BOUND) || lteRsrp > LOWER_BOUND || lteRsrq > LOWER_BOUND) {
+                if (additionalInformation) {
+                    int channelNumber = rsSignal.getInt("channel_number");
+                    item = new SignalGraphItemDTO();
+                    item.setTimeElapsed(Math.max(timeElapsed,0));
+
+                    item = new SignalGraphItemDTO(Math.max(timeElapsed, 0), rsSignal.getString("network_type"), signalStrength, lteRsrp, lteRsrq, rsSignal.getString("cat_technology"),
+                            rsSignal.getInt("location_id"), rsSignal.getInt("area_code"), rsSignal.getInt("primary_scrambling_code"), channelNumber);
                 }
-            }
-
-    		public SignalGraphItem(long timeElapsed, String networkType, Integer signalStrength, Integer lteRsrp, Integer lteRsrq, String catTechnology) {
-    			this.timeElapsed = timeElapsed;
-    			this.networkType = networkType;
-                signalStrength = (signalStrength == 0) ? null : signalStrength;
-                lteRsrp = (lteRsrp == 0) ? null : lteRsrp;
-                lteRsrq = (lteRsrq == 0) ? null : lteRsrq;
-    			this.signalStrength = signalStrength;
-    			this.lteRsrp = lteRsrp;
-    			this.lteRsrq = lteRsrq;
-    			this.catTechnology = catTechnology;
-    		}
-
-    		/**
-    		 * @return The time elapsed since the begin of the test
-    		 */
-    		public long getTimeElapsed() {
-    			return this.timeElapsed;
-    		}
-
-    		/**
-    		 * @return The type of the network, e.g.
-    		 */
-    		public String getNetworkType() {
-    			return this.networkType;
-    		}
-
-       		/**
-    		 * @return The signal strength RSSI in dBm
-    		 */
-    		public Integer getSignalStrength() {
-    			return this.signalStrength;
-    		}
-
-       		/**
-    		 * @return The signal strength RSRP in dBm
-    		 */
-    		public Integer getLteRsrp() {
-    			return this.lteRsrp;
-    		}
-
-       		/**
-    		 * @return The signal quality RSRQ in dB
-    		 */
-    		public Integer getLteRsrq() {
-    			return this.lteRsrq;
-    		}
-
-    		public String getCatTechnology() {
-    			return this.catTechnology;
-    		}
-
-
-            public CellInfo2G getCellInfo2G() {
-                return cellInfo2G;
-            }
-
-            public CellInfo3G getCellInfo3G() {
-                return cellInfo3G;
-            }
-
-            public CellInfo4G getCellInfo4G() {
-                return cellInfo4G;
-            }
-
-            public JSONObject toJSON() {
-                JSONObject json = new JSONObject();
-                json.put("time_elapsed",getTimeElapsed());
-                json.put("network_type", getNetworkType());
-                json.put("signal_strength", (getSignalStrength()==null)? JSONObject.NULL:getSignalStrength());
-                json.put("lte_rsrp", getLteRsrp()==null?JSONObject.NULL:getLteRsrp());
-                json.put("lte_rsrq", getLteRsrq()==null?JSONObject.NULL:getLteRsrq());
-                json.put("cat_technology", getCatTechnology());
-                json.put("cell_info_2G", (getCellInfo2G() == null ? JSONObject.NULL : getCellInfo2G().toJson()));
-                json.put("cell_info_3G", (getCellInfo3G() == null) ? JSONObject.NULL : getCellInfo3G().toJson());
-                json.put("cell_info_4G", (getCellInfo4G() == null) ? JSONObject.NULL : getCellInfo4G().toJson());
-                return json;
-            }
-        }
-
-        public abstract static class CellInfo {
-            private BandCalculationUtil.FrequencyInformation fi;
-
-            protected void setFrequencyInformation(BandCalculationUtil.FrequencyInformation fi) {
-                this.fi = fi;
-            }
-
-            public Double getFrequencyDl() {
-                return (fi == null) ? null : fi.getFrequencyDL();
-            }
-
-            public Integer getBand() {
-                return (fi == null) ? null : fi.getBand();
-            }
-
-            protected JSONObject toJson() {
-                JSONObject jo = new JSONObject();
-                jo.put("frequency_dl", getFrequencyDl() == null ? JSONObject.NULL : getFrequencyDl());
-                jo.put("band", getBand() == null ? JSONObject.NULL : getBand());
-                return jo;
-            }
-        }
-
-        public static class CellInfo2G extends CellInfo {
-            private Integer lac;
-            private Integer cid;
-            private Integer bsic;
-            private Integer arfcn;
-
-            public CellInfo2G(Integer locationId, Integer areaCode, Integer primaryScramblingCode, Integer channelNumber) {
-                lac = locationId;
-                cid = areaCode;
-                bsic= primaryScramblingCode;
-                arfcn = channelNumber;
-                if (channelNumber != null) {
-                    setFrequencyInformation(BandCalculationUtil.getBandFromArfcn(getArfcn()));
-                }
-            }
-
-            public Integer getLac() {
-                return lac;
-            }
-
-            public Integer getCid() {
-                return cid;
-            }
-
-            public Integer getBsic() {
-                return bsic;
-            }
-
-            public Integer getArfcn() {
-                return arfcn;
-            }
-
-            public JSONObject toJson() {
-                JSONObject jo = super.toJson();
-                jo.put("lac", getLac() == null ? JSONObject.NULL : getLac());
-                jo.put("cid", getCid() == null ? JSONObject.NULL : getCid());
-                jo.put("bsic", getBsic() == null ? JSONObject.NULL : getBsic());
-                jo.put("arfcn", getArfcn() == null ? JSONObject.NULL : getArfcn());
-                return jo;
-            }
-        }
-
-        public static class CellInfo3G extends CellInfo {
-            private Integer lac;
-            private Integer cid;
-            private Integer psc;
-            private Integer uarfcn;
-
-            public CellInfo3G(Integer locationId, Integer areaCode, Integer primaryScramblingCode, Integer channelNumber) {
-                lac = locationId;
-                cid = areaCode;
-                psc = primaryScramblingCode;
-                uarfcn = channelNumber;
-
-                if (channelNumber != null) {
-                    setFrequencyInformation(BandCalculationUtil.getBandFromUarfcn(getUarfcn()));
+                else {
+                    item = new SignalGraphItemDTO(Math.max(timeElapsed, 0), rsSignal.getString("network_type"), signalStrength, lteRsrp, lteRsrq, rsSignal.getString("cat_technology"));
                 }
             }
 
 
-            public Integer getLac() {
-                return lac;
-            }
-
-            public Integer getCid() {
-                return cid;
-            }
-
-            public Integer getPsc() {
-                return psc;
-            }
-
-            public Integer getUarfcn() {
-                return uarfcn;
-            }
-
-            public JSONObject toJson() {
-                JSONObject jo = super.toJson();
-                jo.put("lac", getLac() == null ? JSONObject.NULL : getLac());
-                jo.put("cid", getCid() == null ? JSONObject.NULL : getCid());
-                jo.put("psc", getPsc() == null ? JSONObject.NULL : getPsc());
-                jo.put("uarfcn", getUarfcn() == null ? JSONObject.NULL : getUarfcn());
-                return jo;
-            }
-        }
-
-        public static class CellInfo4G extends CellInfo {
-            private Integer tac;
-            private Integer ci;
-            private Integer pci;
-            private Integer earfcn;
-
-            public CellInfo4G(Integer locationId, Integer areaCode, Integer primaryScramblingCode, Integer channelNumber) {
-                tac = locationId;
-                ci = areaCode;
-                pci = primaryScramblingCode;
-                earfcn = channelNumber;
-
-                if (channelNumber != null) {
-                    setFrequencyInformation(BandCalculationUtil.getBandFromEarfcn(getEarfcn()));
+            //put 5-let in the array if it is not the first one
+            if (!first || rsSignal.isLast()) {
+                if (timeElapsed < 0) {
+                    item.setTimeElapsed(1000);
                 }
-            }
-
-
-            public Integer getTac() {
-                return tac;
-            }
-
-            public Integer getCi() {
-                return ci;
-            }
-
-            public Integer getPci() {
-                return pci;
-            }
-
-            public Integer getEarfcn() {
-                return earfcn;
-            }
-
-            public JSONObject toJson() {
-                JSONObject jo = super.toJson();
-                jo.put("tac", getTac() == null ? JSONObject.NULL : getTac());
-                jo.put("ci", getCi() == null ? JSONObject.NULL : getCi());
-                jo.put("pci", getPci() == null ? JSONObject.NULL : getPci());
-                jo.put("earfcn", getEarfcn() == null ? JSONObject.NULL : getEarfcn());
-                return jo;
+                signalList.add(item);
             }
         }
+
+        rsSignal.close();
+        psSignal.close();
+        return signalList;
     }
+
 }

--- a/RMBTStatisticServer/src/at/rtr/rmbt/statisticServer/OpenTestResource.java
+++ b/RMBTStatisticServer/src/at/rtr/rmbt/statisticServer/OpenTestResource.java
@@ -25,6 +25,10 @@ import at.rtr.rmbt.statisticServer.opendata.dto.*;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiImplicitParams;
+import io.swagger.annotations.ApiOperation;
 import org.apache.commons.dbutils.BasicRowProcessor;
 import org.apache.commons.dbutils.GenerousBeanProcessor;
 import org.apache.commons.dbutils.handlers.BeanHandler;
@@ -41,7 +45,11 @@ import at.rtr.rmbt.shared.smoothing.SmoothingFunction;
 
 import com.google.gson.Gson;
 
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
 
+
+@Api(value="/opentests/", description = "Open test search")
 public class OpenTestResource extends ServerResource
 {
     //maximum of rows sent in one single request
@@ -59,8 +67,16 @@ public class OpenTestResource extends ServerResource
      */
     public final static int SMOOTHING_DATA_AMOUNT = 5;
 
-
-    @Get("json")
+    @Path("/opentests/{open-test-uuid}")
+    @ApiOperation(value = "query for OpenTests",
+            response = OpenTestDetailsDTO.class,
+            httpMethod = "GET")
+    @GET
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "open-test-uuid", value = "Mandatory. The open-test-uuid of the test.", dataType = "string", example = "Oc1326b7c-4141-42cb-b8c5-922c356a6cee", paramType = "path", required = true),
+            @ApiImplicitParam(name = "verbose", value = "Optional. If >0 the threadwise speed curve is additionally returned.", dataType = "integer", example = "0", paramType = "query"),
+            @ApiImplicitParam(name = "sender", value = "Optional. ID of the sender, for authentification.", dataType = "string", paramType = "query")
+    })
     public String request(final String entity) {
         int verboseLevel = 0;
         addAllowOrigin();

--- a/RMBTStatisticServer/src/at/rtr/rmbt/statisticServer/OpenTestResource.java
+++ b/RMBTStatisticServer/src/at/rtr/rmbt/statisticServer/OpenTestResource.java
@@ -16,15 +16,16 @@
  ******************************************************************************/
 package at.rtr.rmbt.statisticServer;
 
-import java.sql.*;
-import java.util.*;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
+import at.rtr.rmbt.shared.Classification;
+import at.rtr.rmbt.shared.model.SpeedItems;
+import at.rtr.rmbt.shared.model.SpeedItems.SpeedItem;
+import at.rtr.rmbt.shared.smoothing.Smoothable;
+import at.rtr.rmbt.shared.smoothing.SmoothingFunction;
 import at.rtr.rmbt.statisticServer.opendata.dto.*;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.google.gson.Gson;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiImplicitParam;
 import io.swagger.annotations.ApiImplicitParams;
@@ -37,16 +38,15 @@ import org.restlet.data.Form;
 import org.restlet.data.Status;
 import org.restlet.resource.Get;
 
-import at.rtr.rmbt.shared.Classification;
-import at.rtr.rmbt.shared.model.SpeedItems;
-import at.rtr.rmbt.shared.model.SpeedItems.SpeedItem;
-import at.rtr.rmbt.shared.smoothing.Smoothable;
-import at.rtr.rmbt.shared.smoothing.SmoothingFunction;
-
-import com.google.gson.Gson;
-
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 
 @Api(value="/opentests/", description = "Open test search")
@@ -70,8 +70,10 @@ public class OpenTestResource extends ServerResource
     @Path("/opentests/{open-test-uuid}")
     @ApiOperation(value = "query for OpenTests",
             response = OpenTestDetailsDTO.class,
-            httpMethod = "GET")
+            httpMethod = "GET",
+            nickname = "opentest-query")
     @GET
+    @Get
     @ApiImplicitParams({
             @ApiImplicitParam(name = "open-test-uuid", value = "Mandatory. The open-test-uuid of the test.", dataType = "string", example = "Oc1326b7c-4141-42cb-b8c5-922c356a6cee", paramType = "path", required = true),
             @ApiImplicitParam(name = "verbose", value = "Optional. If >0 the threadwise speed curve is additionally returned.", dataType = "integer", example = "0", paramType = "query"),

--- a/RMBTStatisticServer/src/at/rtr/rmbt/statisticServer/OpenTestResource.java
+++ b/RMBTStatisticServer/src/at/rtr/rmbt/statisticServer/OpenTestResource.java
@@ -49,7 +49,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 
-@Api(value="/opentests/", description = "Open test search")
+@Api(value="/opentests/")
 public class OpenTestResource extends ServerResource
 {
     //maximum of rows sent in one single request
@@ -69,6 +69,7 @@ public class OpenTestResource extends ServerResource
 
     @Path("/opentests/{open-test-uuid}")
     @ApiOperation(value = "query for OpenTests",
+            notes = "Query for a specific measurement result",
             response = OpenTestDetailsDTO.class,
             httpMethod = "GET",
             nickname = "opentest-query")

--- a/RMBTStatisticServer/src/at/rtr/rmbt/statisticServer/StatisticServer.java
+++ b/RMBTStatisticServer/src/at/rtr/rmbt/statisticServer/StatisticServer.java
@@ -59,7 +59,9 @@ public class StatisticServer extends Application
         
         router.attach("/statistics", StatisticsResource.class);
 
+        router.attach("/export/netztest-opendata-{year}-{month}.{format}", ExportResource.class);
         router.attach("/export/netztest-opendata-{year}-{month}.", ExportResource.class, Template.MODE_STARTS_WITH);
+        router.attach("/export/netztest-opendata_hours-{hours}.{format}", ExportResource.class);
         router.attach("/export/netztest-opendata_hours-{hours}.", ExportResource.class, Template.MODE_STARTS_WITH);
         router.attach("/export", ExportResource.class, Template.MODE_STARTS_WITH);
         

--- a/RMBTStatisticServer/src/at/rtr/rmbt/statisticServer/export/ExportResource.java
+++ b/RMBTStatisticServer/src/at/rtr/rmbt/statisticServer/export/ExportResource.java
@@ -352,7 +352,8 @@ public class ExportResource extends ServerResource
                     final CsvSchema schema;
                     cm.setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE);
                     cm.enable(CsvGenerator.Feature.STRICT_CHECK_FOR_QUOTING);
-                    schema = cm.schemaFor(OpenTestExportDTO.class).withHeader();
+                    schema = CsvSchema.builder().setLineSeparator("\r\n").setUseHeader(true)
+                            .addColumnsFrom(cm.schemaFor(OpenTestExportDTO.class)).build();
                     cm.writer(schema).writeValue(outf, results);
                 }
                 

--- a/RMBTStatisticServer/src/at/rtr/rmbt/statisticServer/export/ExportResource.java
+++ b/RMBTStatisticServer/src/at/rtr/rmbt/statisticServer/export/ExportResource.java
@@ -18,12 +18,15 @@ package at.rtr.rmbt.statisticServer.export;
 
 import at.rtr.rmbt.statisticServer.ServerResource;
 import at.rtr.rmbt.statisticServer.opendata.dto.OpenTestExportDTO;
+import at.rtr.rmbt.statisticServer.opendata.dto.OpenTestSearchDTO;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.SequenceWriter;
 import com.fasterxml.jackson.dataformat.csv.CsvGenerator;
 import com.fasterxml.jackson.dataformat.csv.CsvMapper;
 import com.fasterxml.jackson.dataformat.csv.CsvSchema;
 import com.github.sett4.dataformat.xlsx.XlsxMapper;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVPrinter;
 import org.apache.commons.dbutils.BasicRowProcessor;
@@ -36,6 +39,8 @@ import org.restlet.representation.OutputRepresentation;
 import org.restlet.representation.Representation;
 import org.restlet.resource.Get;
 
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
 import java.io.*;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
@@ -49,6 +54,7 @@ import java.util.logging.Logger;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
+@Api(value="/export", description = "Open test export")
 public class ExportResource extends ServerResource
 {
     private static final String FILENAME_CSV_HOURS = "netztest-opendata_hours-%HOURS%.csv";
@@ -67,6 +73,11 @@ public class ExportResource extends ServerResource
     private static long cacheThresholdMs;
 
     @Get
+    @GET
+    @Path("/export")
+    @ApiOperation(httpMethod = "GET",
+            value = "Search for open data tests",
+            response = OpenTestExportDTO.class)
     public Representation request(final String entity)
     {
         //Before doing anything => check if a cached file already exists and is new enough

--- a/RMBTStatisticServer/src/at/rtr/rmbt/statisticServer/export/ExportResource.java
+++ b/RMBTStatisticServer/src/at/rtr/rmbt/statisticServer/export/ExportResource.java
@@ -29,7 +29,6 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiImplicitParam;
 import io.swagger.annotations.ApiImplicitParams;
 import io.swagger.annotations.ApiOperation;
-import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.dbutils.BasicRowProcessor;
 import org.apache.commons.dbutils.GenerousBeanProcessor;
 import org.apache.commons.dbutils.handlers.BeanListHandler;
@@ -68,7 +67,6 @@ public class ExportResource extends ServerResource
     private static final String FILENAME_ZIP_CURRENT = "netztest-opendata.zip";
     private static final String FILENAME_XLSX_CURRENT = "netztest-opendata.xlsx";
 
-    private static final CSVFormat csvFormat = CSVFormat.RFC4180;
     private static final boolean zip = true;
     
     private static long cacheThresholdMs;

--- a/RMBTStatisticServer/src/at/rtr/rmbt/statisticServer/export/ExportResource.java
+++ b/RMBTStatisticServer/src/at/rtr/rmbt/statisticServer/export/ExportResource.java
@@ -55,7 +55,7 @@ import java.util.logging.Logger;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
-@Api(value="/export", description = "Open test export")
+@Api(value="/export")
 public class ExportResource extends ServerResource
 {
     private static final String FILENAME_CSV_HOURS = "netztest-opendata_hours-%HOURS%.csv";
@@ -78,6 +78,7 @@ public class ExportResource extends ServerResource
     @Path("/export/netztest-opendata-{year}-{month}.{format}")
     @ApiOperation(httpMethod = "GET",
             value = "Export open data as CSV or XLSX",
+            notes = "Bulk export open data entries",
             response = OpenTestExportDTO.class,
             produces = "text/csv",
             nickname = "export")

--- a/RMBTStatisticServer/src/at/rtr/rmbt/statisticServer/export/ExportResource.java
+++ b/RMBTStatisticServer/src/at/rtr/rmbt/statisticServer/export/ExportResource.java
@@ -26,9 +26,10 @@ import com.fasterxml.jackson.dataformat.csv.CsvMapper;
 import com.fasterxml.jackson.dataformat.csv.CsvSchema;
 import com.github.sett4.dataformat.xlsx.XlsxMapper;
 import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiImplicitParams;
 import io.swagger.annotations.ApiOperation;
 import org.apache.commons.csv.CSVFormat;
-import org.apache.commons.csv.CSVPrinter;
 import org.apache.commons.dbutils.BasicRowProcessor;
 import org.apache.commons.dbutils.GenerousBeanProcessor;
 import org.apache.commons.dbutils.handlers.BeanListHandler;
@@ -74,10 +75,17 @@ public class ExportResource extends ServerResource
 
     @Get
     @GET
-    @Path("/export")
+    @Path("/export/netztest-opendata-{year}-{month}.{format}")
     @ApiOperation(httpMethod = "GET",
-            value = "Search for open data tests",
-            response = OpenTestExportDTO.class)
+            value = "Export open data as CSV or XLSX",
+            response = OpenTestExportDTO.class,
+            produces = "text/csv",
+            nickname = "export")
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "year", value = "Mandatory. The year that should be exported.", dataType = "string", example = "2017", paramType = "path", required = true),
+            @ApiImplicitParam(name = "month", value = "Mandatory. The year that should be exported.", dataType = "integer", example = "0", paramType = "path", required = true),
+            @ApiImplicitParam(name = "format", value = "Mandatory. Either ZIP (CSV) or XLSX.", dataType = "string", example = "xlsx", paramType = "path", required = true)
+    })
     public Representation request(final String entity)
     {
         //Before doing anything => check if a cached file already exists and is new enough

--- a/RMBTStatisticServer/src/at/rtr/rmbt/statisticServer/opendata/OpenTestSearchResource.java
+++ b/RMBTStatisticServer/src/at/rtr/rmbt/statisticServer/opendata/OpenTestSearchResource.java
@@ -25,9 +25,11 @@ import at.rtr.rmbt.statisticServer.opendata.dto.OpenTestSearchDTO;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.SequenceWriter;
 import com.fasterxml.jackson.dataformat.csv.CsvGenerator;
 import com.fasterxml.jackson.dataformat.csv.CsvMapper;
 import com.fasterxml.jackson.dataformat.csv.CsvSchema;
+import com.github.sett4.dataformat.xlsx.XlsxMapper;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiImplicitParam;
 import io.swagger.annotations.ApiImplicitParams;
@@ -39,6 +41,7 @@ import org.apache.commons.dbutils.handlers.BeanListHandler;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.restlet.data.*;
+import org.restlet.representation.OutputRepresentation;
 import org.restlet.representation.Representation;
 import org.restlet.representation.StringRepresentation;
 import org.restlet.resource.Get;
@@ -46,6 +49,8 @@ import org.restlet.resource.Post;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
+import java.io.IOException;
+import java.io.OutputStream;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -64,6 +69,7 @@ public class OpenTestSearchResource extends ServerResource
     private static final int CACHE_EXP = 3600;
     private static final CSVFormat csvFormat = CSVFormat.RFC4180;
     private static final String CSV_FILENAME = "opentests.csv";
+    private static final String XLSX_FILENAME = "opentests.xlsx";
 
     private final CacheHelper cache = CacheHelper.getInstance();
 
@@ -147,7 +153,18 @@ public class OpenTestSearchResource extends ServerResource
             @ApiImplicitParam(name = "cell_location_id", value = "Number identifying the location of a cell. E.g. the 28-bit Cell Identity (CI) in case of 4G, " +
                     "the 28-bit UMTS Cell Identity (CID) in case of UMTS or the 16-bit GSM Cell Identity (CID) in case of GSM.", dataType = "long", paramType = "query"),
             @ApiImplicitParam(name = "additional_info", value = "additional properties to return", example = "download_classification", dataType = "string", paramType = "query"),
-            @ApiImplicitParam(name = "sender", value = "Sender ID", dataType = "string", paramType = "query")
+            @ApiImplicitParam(name = "format", value="Desired output format, either 'csv' or 'json', default: json", example = "csv", dataType = "string", paramType = "query"),
+            @ApiImplicitParam(name = "sort_by", value="The field for which the data are sorted. Valid fields are: “download_kbit\", \"upload_kbit\", \"time\", \"signal_strength\" and \"ping_ms\"",
+                    example = "download_kbit", dataType = "string", paramType = "query"),
+            @ApiImplicitParam(name = "sort_order", value="The sort_by-Parameter specifies the field, the sort_order-Parameter specifies the direction ('asc' or 'desc').\n " +
+                    "Per Default, the results are sorted by the time of the test in descending order (i.e. sort_by=time&sort_order=desc).\n " +
+                    "If the sort parameters are specified, the value of the cursor is a multiple of the parameter max_results, otherwise it is an arbitrary number.", example = "asc", dataType = "string", paramType = "query"),
+            @ApiImplicitParam(name = "max_results", value="This is the page size, i.e. maximum number of result items that are returned per page.\n " +
+                    "The default value is 100 items per page. The page size limit is 10000 items, i.e. not more than 10000 results can be displayed in a page.", example = "10", dataType = "integer", paramType = "query"),
+            @ApiImplicitParam(name = "cursor", value = "used for pagination if the query returns more than the number of items according to parameter max_results. " +
+                    "The value to be used for the display of the next page is given by the previous response in returned parameter next_cursor.", dataType = "string", paramType = "query"),
+            @ApiImplicitParam(name = "sender", value = "Sender ID", dataType = "string", paramType = "query"),
+            @ApiImplicitParam(name = "timestamp", value = "Alias '_'. Will be ignored and can be used to prevent caching of the response.", dataType = "string", paramType = "query")
     })
     public Representation request(final Representation entity) throws JSONException {
         addAllowOrigin();
@@ -219,38 +236,62 @@ public class OpenTestSearchResource extends ServerResource
             ret = getSearchResult(qp, offset, maxrows, additionalFields, format);
         }
 
-        StringRepresentation sr = null;
+        Representation representation = null;
 
         //format, depending on output format
         try {
-            if (format.equals("json")) {
-                ObjectMapper om = new ObjectMapper();
-                om.setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE);
-                sr = new StringRepresentation(om.writer().writeValueAsString(ret));
-            } else if (format.equals("csv")) {
+            if (format.equals("csv")) {
                 CsvMapper cm = new CsvMapper();
                 cm.setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE);
                 cm.enable(CsvGenerator.Feature.STRICT_CHECK_FOR_QUOTING);
-                CsvSchema schema = cm.schemaFor(OpenTestDTO.class).withHeader();
-                sr = new StringRepresentation(cm.writer(schema).writeValueAsString(ret.getResults()));
+                CsvSchema schema = CsvSchema.builder().setLineSeparator("\r\n").setUseHeader(true)
+                        .addColumnsFrom(cm.schemaFor(OpenTestDTO.class)).build();
+                representation = new StringRepresentation(cm.writer(schema).writeValueAsString(ret.getResults()));
+            }
+            else if (format.equals("xlsx")) {
+                final OpenTestSearchDTO that = ret;
+                OutputRepresentation or = new OutputRepresentation(MediaType.APPLICATION_MSOFFICE_XLSX) {
+                    @Override
+                    public void write(OutputStream outputStream) throws IOException {
+                        XlsxMapper mapper = new XlsxMapper();
+                        mapper.setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE);
+                        CsvSchema schema = mapper.schemaFor(OpenTestDTO.class).withHeader();
+                        SequenceWriter sequenceWriter = mapper.writer(schema).writeValues(outputStream);
+                        sequenceWriter.writeAll(that.getResults());
+                        sequenceWriter.flush();
+                        sequenceWriter.close();
+                    }
+                };
+                return or;
+            }
+            else {
+                ObjectMapper om = new ObjectMapper();
+                om.setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE);
+                representation = new StringRepresentation(om.writer().writeValueAsString(ret));
             }
         } catch (JsonProcessingException e) {
             e.printStackTrace();
             setStatus(Status.SERVER_ERROR_INTERNAL);
         }
 
-        sr.setCharacterSet(CharacterSet.UTF_8);
+        representation.setCharacterSet(CharacterSet.UTF_8);
         if (format.equals("csv")) {
-            //Disposition disposition = new Disposition(Disposition.TYPE_ATTACHMENT);
-            //disposition.setFilename(CSV_FILENAME);
-            sr.setMediaType(MediaType.TEXT_PLAIN);
-            //sr.setDisposition(disposition);
+            Disposition disposition = new Disposition(Disposition.TYPE_ATTACHMENT);
+            disposition.setFilename(CSV_FILENAME);
+            representation.setMediaType(MediaType.TEXT_CSV);
+            representation.setDisposition(disposition);
+        }
+        else if (format.equals("xlsx")) {
+            Disposition disposition = new Disposition(Disposition.TYPE_ATTACHMENT);
+            disposition.setFilename(XLSX_FILENAME);
+            representation.setMediaType(MediaType.APPLICATION_MSOFFICE_XLSX);
+            representation.setDisposition(disposition);
         }
         else {
-            sr.setMediaType(MediaType.APPLICATION_JSON);
+            representation.setMediaType(MediaType.APPLICATION_JSON);
         }
 
-        return sr;
+        return representation;
     }
 
 

--- a/RMBTStatisticServer/src/at/rtr/rmbt/statisticServer/opendata/OpenTestSearchResource.java
+++ b/RMBTStatisticServer/src/at/rtr/rmbt/statisticServer/opendata/OpenTestSearchResource.java
@@ -34,7 +34,6 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiImplicitParam;
 import io.swagger.annotations.ApiImplicitParams;
 import io.swagger.annotations.ApiOperation;
-import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.dbutils.BasicRowProcessor;
 import org.apache.commons.dbutils.GenerousBeanProcessor;
 import org.apache.commons.dbutils.handlers.BeanListHandler;
@@ -67,7 +66,6 @@ public class OpenTestSearchResource extends ServerResource
     private enum FieldType {STRING, DATE, LONG, DOUBLE, BOOLEAN, UUID, SORTBY, SORTORDER, IGNORE};
 
     private static final int CACHE_EXP = 3600;
-    private static final CSVFormat csvFormat = CSVFormat.RFC4180;
     private static final String CSV_FILENAME = "opentests.csv";
     private static final String XLSX_FILENAME = "opentests.xlsx";
 

--- a/RMBTStatisticServer/src/at/rtr/rmbt/statisticServer/opendata/OpenTestSearchResource.java
+++ b/RMBTStatisticServer/src/at/rtr/rmbt/statisticServer/opendata/OpenTestSearchResource.java
@@ -56,7 +56,7 @@ import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-@Api(value="/opentests/search", description = "Open test search")
+@Api(value="/opentests/search")
 public class OpenTestSearchResource extends ServerResource
 {
     private enum FieldType {STRING, DATE, LONG, DOUBLE, BOOLEAN, UUID, SORTBY, SORTORDER, IGNORE};
@@ -94,43 +94,60 @@ public class OpenTestSearchResource extends ServerResource
     @Path("/opentests/search")
     @ApiOperation(httpMethod = "GET",
             value = "Search for open data tests",
-            response = OpenTestSearchDTO.class)
+            response = OpenTestSearchDTO.class,
+            nickname = "search",
+    notes = "Date fields have to be submitted as a number, representing the number of milliseconds that have elapsed since midnight, January 1st, 1970 or " +
+            "in the format “yyyy-MM-dd HH:mm:ss”. The time is given in UTC.\n\n" +
+            "Decimal point (Full Stop “.”) is always used to separate the integer part from the fractional part of a number written in decimal form. " +
+            "This is independent from the local or regional settings.\n\n" +
+            "Numeric fields also allow using the comparators ‘>’ and ‘<’ (meaning ‘=>’ and ‘=<’ respectively). Dates have always to be queried as ranges " +
+            "by using these comparators.\n\n" +
+            "String fields allow using the wildcard ‘*’ for matching any literals and ‘?’ for matching one arbitrary literal.\n\n" +
+            "It is possible, to begin each filter argument with an exclamation mark (!) to negate the filter. E.g. network_type=!LAN will yield all " +
+            "tests where the network type was not LAN.\n\n" +
+            "The criteria denoted with [] can be used more than once in a query. Data has to match all criteria. If an array for one criterion is given, " +
+            "the data has to match each entry.\n\n" +
+            "Generally a query on a parameter value ‘null’ is not possible, except for the parameter loc_accuracy, where the value -1 means ‘null’. " +
+            "Non-‘null’ values are queried with any single or multiple values.")
     @ApiImplicitParams({
             @ApiImplicitParam(name = "download_kbit", value = "Download speed in kilobit per second", dataType = "string", example = ">6903", paramType = "query"),
-            @ApiImplicitParam(name = "upload_kbit", value = "User's email", dataType = "string", example = "<4670", paramType = "query"),
-            @ApiImplicitParam(name = "ping_ms", value = "User ID", dataType = "string", example = "<16", paramType = "query"),
-            @ApiImplicitParam(name = "gkz", value = "User ID", dataType = "string", paramType = "query"),
-            @ApiImplicitParam(name = "gkz_sa", value = "User ID", dataType = "string", paramType = "query"),
-            @ApiImplicitParam(name = "cat_technology", value = "User ID", dataType = "string", paramType = "query"),
-            @ApiImplicitParam(name = "client_version", value = "User ID", dataType = "string", paramType = "query"),
-            @ApiImplicitParam(name = "model", value = "User ID", dataType = "string", paramType = "query"),
-            @ApiImplicitParam(name = "network_name", value = "User ID", dataType = "string", paramType = "query"),
-            @ApiImplicitParam(name = "network_type", value = "User ID", dataType = "string", paramType = "query"),
-            @ApiImplicitParam(name = "platform", value = "User ID", dataType = "string", paramType = "query"),
-            @ApiImplicitParam(name = "signal_strength", value = "User ID", dataType = "string", paramType = "query"),
-            @ApiImplicitParam(name = "open_uuid", value = "User ID", dataType = "string", paramType = "query"),
-            @ApiImplicitParam(name = "open_test_uuid", value = "User ID", dataType = "string", paramType = "query"),
-            @ApiImplicitParam(name = "client_uuid", value = "User ID", dataType = "string", paramType = "query"),
-            @ApiImplicitParam(name = "test_uuid", value = "User ID", dataType = "string", paramType = "query"),
-            @ApiImplicitParam(name = "long", value = "User ID", dataType = "number", paramType = "query"),
-            @ApiImplicitParam(name = "lat", value = "User ID", dataType = "number", paramType = "query"),
-            @ApiImplicitParam(name = "radius", value = "User ID", dataType = "string", paramType = "query"),
-            @ApiImplicitParam(name = "mobile_provider_name", value = "User ID", dataType = "string", paramType = "query"),
-            @ApiImplicitParam(name = "provider_name", value = "User ID", dataType = "string", paramType = "query"),
-            @ApiImplicitParam(name = "sim_mcc_mnc", value = "User ID", dataType = "string", paramType = "query"),
-            @ApiImplicitParam(name = "sim_country", value = "User ID", dataType = "string", paramType = "query"),
-            @ApiImplicitParam(name = "network_country", value = "User ID", dataType = "string", paramType = "query"),
-            @ApiImplicitParam(name = "country_geoip", value = "User ID", dataType = "string", paramType = "query"),
-            @ApiImplicitParam(name = "country_location", value = "User ID", dataType = "string", paramType = "query"),
-            @ApiImplicitParam(name = "user_server_selection", value = "User ID", dataType = "boolean", paramType = "query"),
-            @ApiImplicitParam(name = "loc_accuracy", value = "User ID", dataType = "string", paramType = "query"),
-            @ApiImplicitParam(name = "public_ip_as_name", value = "User ID", dataType = "string", paramType = "query"),
-            @ApiImplicitParam(name = "time", value = "User ID", dataType = "string", paramType = "query"),
-            @ApiImplicitParam(name = "sender", value = "User ID", dataType = "string", paramType = "query"),
+            @ApiImplicitParam(name = "upload_kbit", value = "Upload speed in kilobit per second.", dataType = "string", example = "<4670", paramType = "query"),
+            @ApiImplicitParam(name = "ping_ms", value = "Median ping (round-trip time) in milliseconds, measured on the server side. In previous versions " +
+                    "(before June 3rd 2015) this was the minimum ping measured on the client side.", dataType = "string", example = "<16", paramType = "query"),
+            @ApiImplicitParam(name = "gkz", value = "Community ID (Gemeindekennzahl, see <http://www.bev.gv.at/portal/page?_pageid=713,2601287&_dad=portal&_schema=PORTAL>).", dataType = "string", paramType = "query"),
+            @ApiImplicitParam(name = "gkz_sa", value = "Community ID (Gemeindekennzahl, see <http://www.statistik.at/web_de/klassifikationen/regionale_gliederungen/gemeinden/index.html>)", dataType = "string", paramType = "query"),
+            @ApiImplicitParam(name = "cat_technology", value = "Technology category of the network, e.g. “3G”, “4G”, “WLAN”.", dataType = "string", paramType = "query"),
+            @ApiImplicitParam(name = "client_version", value = "Software version number of the client.", dataType = "string", paramType = "query"),
+            @ApiImplicitParam(name = "model", value = "Name of the device used.", dataType = "string", paramType = "query"),
+            @ApiImplicitParam(name = "network_name", value = "Display name of the mobile network.", dataType = "string", paramType = "query"),
+            @ApiImplicitParam(name = "network_type", value = "Type of the network, e.g. MOBILE, LAN, WLAN.", dataType = "string", paramType = "query"),
+            @ApiImplicitParam(name = "platform", value = "Platform on which the test has been conducted", dataType = "string", paramType = "query"),
+            @ApiImplicitParam(name = "signal_strength", value = "Signal strength (RSSI) in dBm.", dataType = "string", paramType = "query"),
+            @ApiImplicitParam(name = "open_uuid", value = "Open-UUID: Identifies the client that conducted the test. The a new Open-UUID is assigned to the client on a regular basis.", dataType = "string", paramType = "query"),
+            @ApiImplicitParam(name = "open_test_uuid", value = "The UUID of the test.", dataType = "string", paramType = "query"),
+            @ApiImplicitParam(name = "client_uuid", value = "The private UUID of a client", dataType = "string", paramType = "query"),
+            @ApiImplicitParam(name = "test_uuid", value = "The private UUID of a test", dataType = "string", paramType = "query"),
+            @ApiImplicitParam(name = "long", value = "Longitude of the client position.", dataType = "number", paramType = "query"),
+            @ApiImplicitParam(name = "lat", value = "Latitude of the client position.", dataType = "number", paramType = "query"),
+            @ApiImplicitParam(name = "radius", value = "Radius in meters defining based on lat/long parameters", dataType = "string", paramType = "query"),
+            @ApiImplicitParam(name = "mobile_provider_name", value = "mobile operator name", dataType = "string", paramType = "query"),
+            @ApiImplicitParam(name = "provider_name", value = "Name of the internet service provider.", dataType = "string", paramType = "query"),
+            @ApiImplicitParam(name = "sim_mcc_mnc", value = "Network identification of the SIM provider. The digits of MCC and MNC have the same meaning as described in “network_mcc_mnc”.", dataType = "string", paramType = "query"),
+            @ApiImplicitParam(name = "sim_country", value = "Home country of the SIM card in ISO 3166.", dataType = "string", paramType = "query"),
+            @ApiImplicitParam(name = "network_country", value = "Country of the network in ISO 3166.", dataType = "string", paramType = "query"),
+            @ApiImplicitParam(name = "country_geoip", value = "Country according client IP address.", dataType = "string", paramType = "query"),
+            @ApiImplicitParam(name = "country_location", value = "Country of geo-location.", dataType = "string", paramType = "query"),
+            @ApiImplicitParam(name = "user_server_selection", value = "Legacy", dataType = "boolean", paramType = "query"),
+            @ApiImplicitParam(name = "loc_accuracy", value = "Estimation of accuracy of client location in meters", dataType = "string", paramType = "query"),
+            @ApiImplicitParam(name = "public_ip_as_name", value = "Name of the AS of the clients public IP.", dataType = "string", paramType = "query"),
+            @ApiImplicitParam(name = "time", value = "UTC date and time when test was started.", dataType = "string", paramType = "query"),
+            @ApiImplicitParam(name = "radio_band", value = "Radio band used when conducting the test.", dataType = "long", paramType = "query"),
+            @ApiImplicitParam(name = "cell_area_code", value = "Number describing the coarse location of a cell. E.g. the Tracking Area Code (TAC) in case of 4G " +
+                    "or the Location Area Code (LAC) in case of 2G or 3G", dataType = "long", paramType = "query"),
+            @ApiImplicitParam(name = "cell_location_id", value = "Number identifying the location of a cell. E.g. the 28-bit Cell Identity (CI) in case of 4G, " +
+                    "the 28-bit UMTS Cell Identity (CID) in case of UMTS or the 16-bit GSM Cell Identity (CID) in case of GSM.", dataType = "long", paramType = "query"),
             @ApiImplicitParam(name = "additional_info", value = "additional properties to return", example = "download_classification", dataType = "string", paramType = "query"),
-            @ApiImplicitParam(name = "radio_band", value = "User ID", dataType = "long", paramType = "query"),
-            @ApiImplicitParam(name = "cell_area_code", value = "User ID", dataType = "long", paramType = "query"),
-            @ApiImplicitParam(name = "cell_location_id", value = "User ID", dataType = "long", paramType = "query")
+            @ApiImplicitParam(name = "sender", value = "Sender ID", dataType = "string", paramType = "query")
     })
     public Representation request(final Representation entity) throws JSONException {
         addAllowOrigin();

--- a/RMBTStatisticServer/src/at/rtr/rmbt/statisticServer/opendata/OpenTestSearchResource.java
+++ b/RMBTStatisticServer/src/at/rtr/rmbt/statisticServer/opendata/OpenTestSearchResource.java
@@ -262,7 +262,7 @@ public class OpenTestSearchResource extends ServerResource
                         sequenceWriter.close();
                     }
                 };
-                return or;
+                representation = or;
             }
             else {
                 ObjectMapper om = new ObjectMapper();
@@ -274,12 +274,12 @@ public class OpenTestSearchResource extends ServerResource
             setStatus(Status.SERVER_ERROR_INTERNAL);
         }
 
-        representation.setCharacterSet(CharacterSet.UTF_8);
         if (format.equals("csv")) {
             Disposition disposition = new Disposition(Disposition.TYPE_ATTACHMENT);
             disposition.setFilename(CSV_FILENAME);
             representation.setMediaType(MediaType.TEXT_CSV);
             representation.setDisposition(disposition);
+            representation.setCharacterSet(CharacterSet.UTF_8);
         }
         else if (format.equals("xlsx")) {
             Disposition disposition = new Disposition(Disposition.TYPE_ATTACHMENT);
@@ -289,6 +289,7 @@ public class OpenTestSearchResource extends ServerResource
         }
         else {
             representation.setMediaType(MediaType.APPLICATION_JSON);
+            representation.setCharacterSet(CharacterSet.UTF_8);
         }
 
         return representation;

--- a/RMBTStatisticServer/src/at/rtr/rmbt/statisticServer/opendata/OpenTestSearchResource.java
+++ b/RMBTStatisticServer/src/at/rtr/rmbt/statisticServer/opendata/OpenTestSearchResource.java
@@ -153,7 +153,7 @@ public class OpenTestSearchResource extends ServerResource
             @ApiImplicitParam(name = "cell_location_id", value = "Number identifying the location of a cell. E.g. the 28-bit Cell Identity (CI) in case of 4G, " +
                     "the 28-bit UMTS Cell Identity (CID) in case of UMTS or the 16-bit GSM Cell Identity (CID) in case of GSM.", dataType = "long", paramType = "query"),
             @ApiImplicitParam(name = "additional_info", value = "additional properties to return", example = "download_classification", dataType = "string", paramType = "query"),
-            @ApiImplicitParam(name = "format", value="Desired output format, either 'csv' or 'json', default: json", example = "csv", dataType = "string", paramType = "query"),
+            @ApiImplicitParam(name = "format", value="Desired output format, either 'csv' or 'json', default: json", example = "json", dataType = "string", paramType = "query"),
             @ApiImplicitParam(name = "sort_by", value="The field for which the data are sorted. Valid fields are: “download_kbit\", \"upload_kbit\", \"time\", \"signal_strength\" and \"ping_ms\"",
                     example = "download_kbit", dataType = "string", paramType = "query"),
             @ApiImplicitParam(name = "sort_order", value="The sort_by-Parameter specifies the field, the sort_order-Parameter specifies the direction ('asc' or 'desc').\n " +

--- a/RMBTStatisticServer/src/at/rtr/rmbt/statisticServer/opendata/OpenTestSearchResource.java
+++ b/RMBTStatisticServer/src/at/rtr/rmbt/statisticServer/opendata/OpenTestSearchResource.java
@@ -1,13 +1,13 @@
 /*******************************************************************************
  * Copyright 2013-2016 Thomas Schreiber
  * Copyright 2013-2016 Rundfunk und Telekom Regulierungs-GmbH (RTR-GmbH)
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -28,6 +28,10 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.dataformat.csv.CsvGenerator;
 import com.fasterxml.jackson.dataformat.csv.CsvMapper;
 import com.fasterxml.jackson.dataformat.csv.CsvSchema;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiImplicitParams;
+import io.swagger.annotations.ApiOperation;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.dbutils.BasicRowProcessor;
 import org.apache.commons.dbutils.GenerousBeanProcessor;
@@ -40,6 +44,8 @@ import org.restlet.representation.StringRepresentation;
 import org.restlet.resource.Get;
 import org.restlet.resource.Post;
 
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -50,6 +56,7 @@ import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+@Api(value="/opentests/search", description = "Open test search")
 public class OpenTestSearchResource extends ServerResource
 {
     private enum FieldType {STRING, DATE, LONG, DOUBLE, BOOLEAN, UUID, SORTBY, SORTORDER, IGNORE};
@@ -57,25 +64,25 @@ public class OpenTestSearchResource extends ServerResource
     private static final int CACHE_EXP = 3600;
     private static final CSVFormat csvFormat = CSVFormat.RFC4180;
     private static final String CSV_FILENAME = "opentests.csv";
-    
+
     private final CacheHelper cache = CacheHelper.getInstance();
-    
+
     public final int MAXROWS = 10000;  //maximum number of rows allowed, currently approx 1.5s response time at maximum
     public final int DEFAULTROWS = 100; //default number of rows (when max_results is not specified)
     public final int MAXQUERYFIELDS = 50; //to prevent database-server overload
-    
-    
+
+
       //all fields that should be displayed in a general request (e.g. all tests for one user)
-    private final String[] openDataFieldsSummary = {"open_uuid", "open_test_uuid", "time", "lat", "long", "download_kbit", "upload_kbit", 
+    private final String[] openDataFieldsSummary = {"open_uuid", "open_test_uuid", "time", "lat", "long", "download_kbit", "upload_kbit",
         "ping_ms", "signal_strength", "lte_rsrp",  "platform", "provider_name", "model", "loc_accuracy"};
 
     //all fields that are numbers (and are formatted as numbers in json)
     private final HashSet<String> openDataNumberFields = new HashSet<>(Arrays.asList(new String[]{"time", "lat", "long", "download_kbit",
         "upload_kbit","ping_ms","signal_strength", "lte_rsrp", "test_duration","num_threads","ndt_download_kbit","ndt_upload_kbit","asn","loc_accuracy"}));
- 
+
     //all fields for which the user can sort the result
     private final HashSet<String> openDataFieldsSortable = new HashSet<>(Arrays.asList(new String[]{"download_kbit","upload_kbit","time","signal_strength","ping_ms"}));
-    
+
     //additional fields that the user is allowed to request
     private final HashSet<String> allowedAdditionalFields = new HashSet<>(Arrays.asList(new String[] {"download_classification","upload_classification","ping_classification"}));
 
@@ -83,6 +90,48 @@ public class OpenTestSearchResource extends ServerResource
 
     @Get
     @Post
+    @GET
+    @Path("/opentests/search")
+    @ApiOperation(httpMethod = "GET",
+            value = "Search for open data tests",
+            response = OpenTestSearchDTO.class)
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "download_kbit", value = "Download speed in kilobit per second", dataType = "string", example = ">6903", paramType = "query"),
+            @ApiImplicitParam(name = "upload_kbit", value = "User's email", dataType = "string", example = "<4670", paramType = "query"),
+            @ApiImplicitParam(name = "ping_ms", value = "User ID", dataType = "string", example = "<16", paramType = "query"),
+            @ApiImplicitParam(name = "gkz", value = "User ID", dataType = "string", paramType = "query"),
+            @ApiImplicitParam(name = "gkz_sa", value = "User ID", dataType = "string", paramType = "query"),
+            @ApiImplicitParam(name = "cat_technology", value = "User ID", dataType = "string", paramType = "query"),
+            @ApiImplicitParam(name = "client_version", value = "User ID", dataType = "string", paramType = "query"),
+            @ApiImplicitParam(name = "model", value = "User ID", dataType = "string", paramType = "query"),
+            @ApiImplicitParam(name = "network_name", value = "User ID", dataType = "string", paramType = "query"),
+            @ApiImplicitParam(name = "network_type", value = "User ID", dataType = "string", paramType = "query"),
+            @ApiImplicitParam(name = "platform", value = "User ID", dataType = "string", paramType = "query"),
+            @ApiImplicitParam(name = "signal_strength", value = "User ID", dataType = "string", paramType = "query"),
+            @ApiImplicitParam(name = "open_uuid", value = "User ID", dataType = "string", paramType = "query"),
+            @ApiImplicitParam(name = "open_test_uuid", value = "User ID", dataType = "string", paramType = "query"),
+            @ApiImplicitParam(name = "client_uuid", value = "User ID", dataType = "string", paramType = "query"),
+            @ApiImplicitParam(name = "test_uuid", value = "User ID", dataType = "string", paramType = "query"),
+            @ApiImplicitParam(name = "long", value = "User ID", dataType = "number", paramType = "query"),
+            @ApiImplicitParam(name = "lat", value = "User ID", dataType = "number", paramType = "query"),
+            @ApiImplicitParam(name = "radius", value = "User ID", dataType = "string", paramType = "query"),
+            @ApiImplicitParam(name = "mobile_provider_name", value = "User ID", dataType = "string", paramType = "query"),
+            @ApiImplicitParam(name = "provider_name", value = "User ID", dataType = "string", paramType = "query"),
+            @ApiImplicitParam(name = "sim_mcc_mnc", value = "User ID", dataType = "string", paramType = "query"),
+            @ApiImplicitParam(name = "sim_country", value = "User ID", dataType = "string", paramType = "query"),
+            @ApiImplicitParam(name = "network_country", value = "User ID", dataType = "string", paramType = "query"),
+            @ApiImplicitParam(name = "country_geoip", value = "User ID", dataType = "string", paramType = "query"),
+            @ApiImplicitParam(name = "country_location", value = "User ID", dataType = "string", paramType = "query"),
+            @ApiImplicitParam(name = "user_server_selection", value = "User ID", dataType = "boolean", paramType = "query"),
+            @ApiImplicitParam(name = "loc_accuracy", value = "User ID", dataType = "string", paramType = "query"),
+            @ApiImplicitParam(name = "public_ip_as_name", value = "User ID", dataType = "string", paramType = "query"),
+            @ApiImplicitParam(name = "time", value = "User ID", dataType = "string", paramType = "query"),
+            @ApiImplicitParam(name = "sender", value = "User ID", dataType = "string", paramType = "query"),
+            @ApiImplicitParam(name = "additional_info", value = "additional properties to return", example = "download_classification", dataType = "string", paramType = "query"),
+            @ApiImplicitParam(name = "radio_band", value = "User ID", dataType = "long", paramType = "query"),
+            @ApiImplicitParam(name = "cell_area_code", value = "User ID", dataType = "long", paramType = "query"),
+            @ApiImplicitParam(name = "cell_location_id", value = "User ID", dataType = "long", paramType = "query")
+    })
     public Representation request(final Representation entity) throws JSONException {
         addAllowOrigin();
 
@@ -187,8 +236,8 @@ public class OpenTestSearchResource extends ServerResource
         return sr;
     }
 
-    
-    
+
+
     /**
      * Gets a JSON-String containing all open-data-values of all rows
      * that matched the given criteria
@@ -196,7 +245,7 @@ public class OpenTestSearchResource extends ServerResource
      * @param offset a offset-value for paging (given as "next-cursor" in the response), -1 if none is set
      * @param maxrows maximal count of rows returned
      * @param additionalFields additional fields that should be included in the response
-     * @return 
+     * @return
      */
     private OpenTestSearchDTO getSearchResult(QueryParser qp, long offset, long maxrows, Set<String> additionalFields, final String format) {
         long startTime = System.currentTimeMillis();
@@ -204,7 +253,7 @@ public class OpenTestSearchResource extends ServerResource
 
         String offsetString = (offset>0)? " AND t.uid<"+offset:""; //if no sorting is used
         String offsetString2 = (offset>0)? " OFFSET "+offset:""; //if sorting is used => may have concurrency issues in the results
-        
+
         String orderClause = qp.getOrderClause();
         boolean defaultOrder = true;
         if (orderClause == null || orderClause.isEmpty()) {
@@ -214,13 +263,13 @@ public class OpenTestSearchResource extends ServerResource
             defaultOrder = false;
             offsetString = "";
         }
-        
+
         if (maxrows>MAXROWS)
         	maxrows = MAXROWS;
         if (maxrows <= 0)
             maxrows = DEFAULTROWS;
-        
-        
+
+
         //There are many LEFT JOINs in the sql statement that are usual not needed.
         //This has no significant impact on the performance since our DBMS (postgres)
         //is intelligent enough to ignore these during query optimization if they are
@@ -228,7 +277,7 @@ public class OpenTestSearchResource extends ServerResource
         final String sql = "SELECT" +
                 " t.uid as cursor, " + //only for pagination
                 " ('P' || t.open_uuid) open_uuid," +
-                " ('O' || t.open_test_uuid) open_test_uuid," + 
+                " ('O' || t.open_test_uuid) open_test_uuid," +
                 " to_char(t.time AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS') \"time\"," +
                 //" nt.group_name cat_technology," +
                 //" nt.name network_type," +
@@ -281,14 +330,14 @@ public class OpenTestSearchResource extends ServerResource
                 " (t.deleted = false)" +
                 " AND status = 'FINISHED' " + qp.getWhereClause("AND") + offsetString +
                 orderClause + " LIMIT " + maxrows + offsetString2;
-        
-        
+
+
         PreparedStatement ps = null;
         ResultSet rs = null;
         try
         {
             ps = conn.prepareStatement(sql);
-            
+
             //don't show coordinates when not accurate enough
             double accuracy = Double.parseDouble(settings.getString("RMBT_GEO_ACCURACY_DETAIL_LIMIT"));
             ps.setDouble(1, accuracy);
@@ -344,7 +393,7 @@ public class OpenTestSearchResource extends ServerResource
                 }
             }
 
-        }     
+        }
         catch (SQLException ex) {
             try {
                 setStatus(Status.CLIENT_ERROR_NOT_FOUND);

--- a/RMBTStatisticServer/src/at/rtr/rmbt/statisticServer/opendata/OpenTestSearchResource.java
+++ b/RMBTStatisticServer/src/at/rtr/rmbt/statisticServer/opendata/OpenTestSearchResource.java
@@ -17,28 +17,38 @@
 package at.rtr.rmbt.statisticServer.opendata;
 
 
-import java.io.IOException;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.util.*;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
+import at.rtr.rmbt.shared.Classification;
+import at.rtr.rmbt.shared.cache.CacheHelper;
+import at.rtr.rmbt.statisticServer.ServerResource;
+import at.rtr.rmbt.statisticServer.opendata.dto.OpenTestDTO;
+import at.rtr.rmbt.statisticServer.opendata.dto.OpenTestSearchDTO;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.dataformat.csv.CsvGenerator;
+import com.fasterxml.jackson.dataformat.csv.CsvMapper;
+import com.fasterxml.jackson.dataformat.csv.CsvSchema;
 import org.apache.commons.csv.CSVFormat;
-import org.apache.commons.csv.CSVPrinter;
-import org.json.JSONArray;
+import org.apache.commons.dbutils.BasicRowProcessor;
+import org.apache.commons.dbutils.GenerousBeanProcessor;
+import org.apache.commons.dbutils.handlers.BeanListHandler;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.restlet.data.*;
 import org.restlet.representation.Representation;
 import org.restlet.representation.StringRepresentation;
 import org.restlet.resource.Get;
-
-import at.rtr.rmbt.shared.Classification;
-import at.rtr.rmbt.shared.cache.CacheHelper;
-import at.rtr.rmbt.statisticServer.ServerResource;
 import org.restlet.resource.Post;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public class OpenTestSearchResource extends ServerResource
 {
@@ -90,7 +100,8 @@ public class OpenTestSearchResource extends ServerResource
         final QueryParser qp = new QueryParser();
 
         final Set<String> additionalFields;
-        final JSONArray invalidElements = qp.parseQuery(getParameters);
+        final List<String> invalidElements = qp.parseQuery(getParameters);
+        OpenTestSearchDTO ret = new OpenTestSearchDTO();
 
 
         //calculate offset
@@ -114,7 +125,7 @@ public class OpenTestSearchResource extends ServerResource
             String param = (getParameters.getNames().contains("additional_info")) ? "additional_info" : "additional_info[]";
             for (String field : getParameters.getValuesArray(param)) {
                 if (!allowedAdditionalFields.contains(field)) {
-                    invalidElements.put(param);
+                    invalidElements.add(param);
                 }
             }
             additionalFields = new HashSet<>(Arrays.asList(getParameters.getValuesArray(param)));
@@ -122,36 +133,52 @@ public class OpenTestSearchResource extends ServerResource
             additionalFields = new HashSet<>();
         }
 
-        String ret;
         String format = getParameters.getFirstValue("format", "json").toLowerCase();;
 
         //if there have been errors => inform the user
-        if (invalidElements.length() > 0) {
+        if (invalidElements.size() > 0) {
             setStatus(Status.CLIENT_ERROR_BAD_REQUEST);
             response.put("invalid_fields", invalidElements);
-            ret = response.toString();
+            ret.getInvalidFields().addAll(invalidElements);
         }
 
         //if there are too many query elements (DoS-Attack?), don't let it
         //get to the database
         else if (qp.getWhereParams().keySet().size() > MAXQUERYFIELDS) {
             setStatus(Status.CLIENT_ERROR_BAD_REQUEST);
-            response.put("invalid_fields", "field limit exceeded");
-            ret = response.toString();
+            ret.getInvalidFields().add("field limit exceeded");
         }
         else {
-            //output format
+            //if valid input, query the db
             ret = getSearchResult(qp, offset, maxrows, additionalFields, format);
-
         }
 
-        StringRepresentation sr = new StringRepresentation(ret);
+        StringRepresentation sr = null;
+
+        //format, depending on output format
+        try {
+            if (format.equals("json")) {
+                ObjectMapper om = new ObjectMapper();
+                om.setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE);
+                sr = new StringRepresentation(om.writer().writeValueAsString(ret));
+            } else if (format.equals("csv")) {
+                CsvMapper cm = new CsvMapper();
+                cm.setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE);
+                cm.enable(CsvGenerator.Feature.STRICT_CHECK_FOR_QUOTING);
+                CsvSchema schema = cm.schemaFor(OpenTestDTO.class).withHeader();
+                sr = new StringRepresentation(cm.writer(schema).writeValueAsString(ret.getResults()));
+            }
+        } catch (JsonProcessingException e) {
+            e.printStackTrace();
+            setStatus(Status.SERVER_ERROR_INTERNAL);
+        }
+
         sr.setCharacterSet(CharacterSet.UTF_8);
         if (format.equals("csv")) {
-            Disposition disposition = new Disposition(Disposition.TYPE_ATTACHMENT);
-            disposition.setFilename(CSV_FILENAME);
-            sr.setMediaType(MediaType.TEXT_CSV);
-            sr.setDisposition(disposition);
+            //Disposition disposition = new Disposition(Disposition.TYPE_ATTACHMENT);
+            //disposition.setFilename(CSV_FILENAME);
+            sr.setMediaType(MediaType.TEXT_PLAIN);
+            //sr.setDisposition(disposition);
         }
         else {
             sr.setMediaType(MediaType.APPLICATION_JSON);
@@ -171,8 +198,10 @@ public class OpenTestSearchResource extends ServerResource
      * @param additionalFields additional fields that should be included in the response
      * @return 
      */
-    private String getSearchResult(QueryParser qp, long offset, long maxrows, Set<String> additionalFields, final String format) {
+    private OpenTestSearchDTO getSearchResult(QueryParser qp, long offset, long maxrows, Set<String> additionalFields, final String format) {
         long startTime = System.currentTimeMillis();
+        OpenTestSearchDTO dto = new OpenTestSearchDTO();
+
         String offsetString = (offset>0)? " AND t.uid<"+offset:""; //if no sorting is used
         String offsetString2 = (offset>0)? " OFFSET "+offset:""; //if sorting is used => may have concurrency issues in the results
         
@@ -210,14 +239,14 @@ public class OpenTestSearchResource extends ServerResource
                 " WHEN (t.geo_accuracy < ?) THEN" +
                 " ROUND(t.geo_lat*1111)/1111" + // approx 100m
                 " ELSE null" +
-                " END) lat," +
+                " END) latitude," +
                 // csv 7:long
                 " (CASE WHEN (t.geo_accuracy < ?) AND (t.geo_provider IS DISTINCT FROM 'manual') AND (t.geo_provider IS DISTINCT FROM 'geocoder') THEN" +
                 " t.geo_long" +
                 " WHEN (t.geo_accuracy < ?) THEN" +
                 " ROUND(t.geo_long*741)/741 " + //approx 100m
                 " ELSE null" +
-                " END) long," +
+                " END) longitude," +
 	             // accuracy of geo location in m
 	             " (CASE WHEN (t.geo_accuracy < ?) AND (t.geo_provider IS DISTINCT FROM 'manual') AND (t.geo_provider IS DISTINCT FROM 'geocoder') " +
 	             " THEN t.geo_accuracy " +
@@ -256,9 +285,6 @@ public class OpenTestSearchResource extends ServerResource
         
         PreparedStatement ps = null;
         ResultSet rs = null;
-        final JSONObject jsonResponse = new JSONObject();
-        final StringBuffer csvResponse = new StringBuffer();
-        final JSONArray resultList = new JSONArray();
         try
         {
             ps = conn.prepareStatement(sql);
@@ -275,51 +301,53 @@ public class OpenTestSearchResource extends ServerResource
             //fill in values for WHERE
             //ps = fillInWhereClause(ps, searchValues, 1);
             qp.fillInWhereClause(ps, 7);
-            
-            //Logger.getLogger(OpenTestResource.class.getName()).log(Level.INFO, "prepstmt" + ps);
-            
-            
-            
+
             if (!ps.execute())
                 return null;
             rs = ps.getResultSet();
 
+            BeanListHandler<OpenTestDTO> handler = new BeanListHandler<>(OpenTestDTO.class,new BasicRowProcessor(new GenerousBeanProcessor()));
+            List<OpenTestDTO> results = handler.handle(rs);
 
-            
-            long lastUID = 0; //remember last uid for pagination since rs can only be traversed in one direction
-            if (format.equals("json")) {
-                lastUID = mapToJson(rs, additionalFields, resultList);
-            }
-            else if (format.equals("csv")) {
-                mapToCsv(rs, additionalFields, csvResponse);
-            }
+            dto.setResults(results);
 
+            //remember last uid for pagination since rs can only be traversed in one direction
             //if there are more results than we send, use pagination
-            if (resultList.length() == maxrows) {
+            if (dto.getResults().size() == maxrows) {
                 //if it is the standard sort order
                 if (defaultOrder) {
-                    jsonResponse.put("next_cursor", lastUID);
+                    dto.setNextCursor(results.get(results.size() - 1).getCursor());
                 } else {
                     offset = (offset<0) ? 0 : offset;
-                    jsonResponse.put("next_cursor", offset+maxrows);
+                    dto.setNextCursor(offset + maxrows);
                 }
             } else {
-                jsonResponse.put("next_cursor", JSONObject.NULL);
+                dto.setNextCursor(null);
             }
 
-            
-            jsonResponse.put("results", resultList);
-            
             //also put in the result, how long the query took to execute
             long elapsedTime = System.currentTimeMillis() - startTime;
-            jsonResponse.put("duration_ms",elapsedTime);
+            //jsonResponse.put("duration_ms",elapsedTime);
+            dto.setDurationMs(elapsedTime);
+
+            if (additionalFields != null) {
+                for (OpenTestDTO result : dto.getResults()) {
+                    if (additionalFields.contains("download_classification")) {
+                        result.setDownloadClassification(Classification.classify(Classification.THRESHOLD_DOWNLOAD, result.getDownloadKbit(), 4));
+                    }
+                    if (additionalFields.contains("upload_classification")) {
+                        result.setUploadClassification(Classification.classify(Classification.THRESHOLD_UPLOAD, result.getUploadKbit(), 4));
+                    }
+                    if (additionalFields.contains("ping_classification")) {
+                        result.setPingClassification(Classification.classify(Classification.THRESHOLD_PING, Math.round(result.getPingMs() * 1000000), 4));
+                    }
+                }
+            }
+
         }     
-        catch (final JSONException | IOException e) {
-            Logger.getLogger(OpenTestSearchResource.class.getName()).log(Level.SEVERE, null, e);
-        } catch (SQLException ex) {
+        catch (SQLException ex) {
             try {
                 setStatus(Status.CLIENT_ERROR_NOT_FOUND);
-                jsonResponse.put("error","invalid parameters");
             } catch (JSONException ex1) {
                 Logger.getLogger(OpenTestSearchResource.class.getName()).log(Level.SEVERE, null, ex1);
             }
@@ -339,117 +367,8 @@ public class OpenTestSearchResource extends ServerResource
                 Logger.getLogger(OpenTestSearchResource.class.getName()).log(Level.SEVERE, null, e);
             }
         }
-
-        if (format.equals("csv")) {
-            return csvResponse.toString();
-
-        }
-        else {
-            return jsonResponse.toString();
-        }
+        return dto;
     }
 
-    /**
-     * Map a ResultSet to the provided JSONArray,
-     * return the uid from the last row
-     *
-     * @param rs
-     * @param additionalFields
-     * @param ret
-     * @return
-     * @throws SQLException
-     * @throws JSONException
-     */
-    public long mapToJson(ResultSet rs, Set<String> additionalFields, JSONArray ret) throws SQLException, JSONException {
-        long lastUID = 0;
-        while (rs.next())
-        {
-            final JSONObject jsonItem = new JSONObject();
-            final HashMap<String, Object> item = new HashMap<>();
-
-            for (int i=0;i<openDataFieldsSummary.length;i++) {
-                final Object obj = rs.getObject(openDataFieldsSummary[i]);
-                if (obj==null) {
-                    jsonItem.put(openDataFieldsSummary[i], JSONObject.NULL);
-                } else if (openDataNumberFields.contains(openDataFieldsSummary[i])) {
-                    final String tmp = obj.toString().trim();
-                    if (tmp.isEmpty())
-                        jsonItem.put(openDataFieldsSummary[i], JSONObject.NULL);
-                    else
-                        jsonItem.put(openDataFieldsSummary[i], JSONObject.stringToValue(tmp));
-                } else {
-                    jsonItem.put(openDataFieldsSummary[i], obj.toString());
-                }
-
-            }
-
-            // add additional fields if requested by user
-            if (additionalFields != null) {
-                if (additionalFields.contains("download_classification")) {
-                    jsonItem.put("download_classification", Classification.classify(Classification.THRESHOLD_DOWNLOAD,rs.getLong("download_kbit"), 4));
-                }
-                if (additionalFields.contains("upload_classification")) {
-                    jsonItem.put("upload_classification", Classification.classify(Classification.THRESHOLD_UPLOAD,rs.getLong("upload_kbit"), 4));
-                }
-                if (additionalFields.contains("ping_classification")) {
-                    jsonItem.put("ping_classification", Classification.classify(Classification.THRESHOLD_PING,rs.getLong("ping_ms") * 1000000, 4));
-                }
-            }
-            ret.put(jsonItem);
-            lastUID = rs.getLong("cursor");
-        }
-
-        return lastUID;
-    }
-
-    /**
-     * Map a ResultSet into the provided StringBuffer
-     * in CSV format
-     *
-     * @param rs
-     * @param additionalFields
-     * @param ret
-     * @throws IOException
-     * @throws SQLException
-     */
-    public void mapToCsv(ResultSet rs, Set<String> additionalFields, StringBuffer ret) throws IOException, SQLException {
-        final CSVPrinter csvPrinter = new CSVPrinter(ret, csvFormat);
-
-
-        //add titles
-        for (int i=0;i<openDataFieldsSummary.length;i++) {
-            csvPrinter.print(openDataFieldsSummary[i]);
-        }
-
-        //add additional Fields
-        for (String additionalField : additionalFields) {
-            csvPrinter.print(additionalField);
-        }
-        csvPrinter.println();
-
-
-        //add values
-        while (rs.next())
-        {
-            for (int i=0;i<openDataFieldsSummary.length;i++) {
-                Object val = rs.getObject(openDataFieldsSummary[i]);
-                csvPrinter.print(val);
-            }
-            if (additionalFields != null) {
-                if (additionalFields.contains("download_classification")) {
-                    csvPrinter.print(Classification.classify(Classification.THRESHOLD_DOWNLOAD,rs.getLong("download_kbit"), 4));
-                }
-                if (additionalFields.contains("upload_classification")) {
-                    csvPrinter.print(Classification.classify(Classification.THRESHOLD_UPLOAD,rs.getLong("upload_kbit"), 4));
-                }
-                if (additionalFields.contains("ping_classification")) {
-                    csvPrinter.print(Classification.classify(Classification.THRESHOLD_PING,rs.getLong("ping_ms") * 1000000, 4));
-                }
-            }
-            csvPrinter.println();
-        }
-
-        csvPrinter.flush();
-    }
 }
 

--- a/RMBTStatisticServer/src/at/rtr/rmbt/statisticServer/opendata/QueryParser.java
+++ b/RMBTStatisticServer/src/at/rtr/rmbt/statisticServer/opendata/QueryParser.java
@@ -180,13 +180,13 @@ public class QueryParser {
         allowedFields.put("format", FieldType.OUTPUT_FORMAT);
     }
     
-    public JSONArray parseQuery(Form getParameters) {
+    public List<String> parseQuery(Form getParameters) {
         //Values for the database
         searchValues.clear();
 
         this.whereClause = "";
         this.orderClause = "";
-        final JSONArray invalidElements = new JSONArray();
+        final List<String> invalidElements = new ArrayList<>();
         final JSONObject response = new JSONObject();
         
         String sortBy="";
@@ -194,7 +194,7 @@ public class QueryParser {
         for (String attr : getParameters.getNames()) {
             //check if attribute is allowed
             if (!allowedFields.containsKey(attr)) {
-                invalidElements.put(attr);
+                invalidElements.add(attr);
                 continue;
             }
 
@@ -213,7 +213,7 @@ public class QueryParser {
                 switch (type) {
                     case STRING:
                         if (value.isEmpty()) {
-                            invalidElements.put(attr);
+                            invalidElements.add(attr);
                             continue;
                         }
                         //allow using wildcard '*' instead of sql '%'
@@ -235,7 +235,7 @@ public class QueryParser {
                             //try parsing the date
                             long v = parseDate(value);
                             if (v == -1) {
-                                invalidElements.put(attr);
+                                invalidElements.add(attr);
                                 continue;
                             }
                             
@@ -250,7 +250,7 @@ public class QueryParser {
                         break;
                     case UUID:
                         if (value.isEmpty()) {
-                            invalidElements.put(attr);
+                            invalidElements.add(attr);
                             continue;
                         }
 
@@ -263,7 +263,7 @@ public class QueryParser {
                                 UUID.fromString(uuid);
                             }
                         } catch(IllegalArgumentException e) {
-                            invalidElements.put(attr);
+                            invalidElements.add(attr);
                             continue;
                         }
                         this.addToWhereParams(attr, value, "=", negate, type);
@@ -271,7 +271,7 @@ public class QueryParser {
                     case BOOLEAN:
                     	if (value.isEmpty() ||
                 			(!value.toLowerCase().equals("false") && !value.toLowerCase().equals("true"))) {
-                            invalidElements.put(attr);
+                            invalidElements.add(attr);
                             continue;
                         }
                         this.addToWhereParams(attr, value, "=", negate, type);
@@ -285,7 +285,7 @@ public class QueryParser {
                             value = value.substring(1);
                         }
                         if (value.isEmpty() || (type == FieldType.DOUBLE && !isDouble(value)) || (type == FieldType.LONG && !isLong(value))) {
-                            invalidElements.put(attr);
+                            invalidElements.add(attr);
                             continue;
                         }
                         this.addToWhereParams(attr, value, comperator, negate, type);
@@ -294,7 +294,7 @@ public class QueryParser {
                     	break; //do nothing
                     case SORTBY:
                         if (value.isEmpty() || !openDataFieldsSortable.contains(value)) {
-                            invalidElements.put(attr);
+                            invalidElements.add(attr);
                             continue;
                         }
                         sortBy = value;
@@ -305,14 +305,14 @@ public class QueryParser {
                         if (value.isEmpty() || 
                                 (!value.toUpperCase().equals("ASC") && !value.toUpperCase().equals("DESC")) || 
                                 !getParameters.getNames().contains("sort_by")) {
-                            invalidElements.put(attr);
+                            invalidElements.add(attr);
                             continue;
                         }
                         sortOrder = value;
                         break;
                     case OUTPUT_FORMAT:
                         if (value.isEmpty() || !(value.toLowerCase().equals("json") || (value.toLowerCase().equals("csv")))) {
-                            invalidElements.put(attr);
+                            invalidElements.add(attr);
                             continue;
                         }
                         break;
@@ -321,7 +321,7 @@ public class QueryParser {
             
         }
 
-        if (invalidElements.length() == 0) {
+        if (invalidElements.size() == 0) {
             //special treatment for radius (Since lat/long are removed from the list in the process)
             if (whereParams.containsKey("radius")) {
                 whereClause += this.formatWhereClause(whereParams.get("radius").get(0),searchValues);

--- a/RMBTStatisticServer/src/at/rtr/rmbt/statisticServer/opendata/QueryParser.java
+++ b/RMBTStatisticServer/src/at/rtr/rmbt/statisticServer/opendata/QueryParser.java
@@ -311,7 +311,8 @@ public class QueryParser {
                         sortOrder = value;
                         break;
                     case OUTPUT_FORMAT:
-                        if (value.isEmpty() || !(value.toLowerCase().equals("json") || (value.toLowerCase().equals("csv")))) {
+                        if (value.isEmpty() || !(value.toLowerCase().equals("json") || (value.toLowerCase().equals("csv")) ||
+                                (value.toLowerCase().equals("xlsx")) )) {
                             invalidElements.add(attr);
                             continue;
                         }

--- a/RMBTStatisticServer/src/at/rtr/rmbt/statisticServer/opendata/dto/LocationGraphDTO.java
+++ b/RMBTStatisticServer/src/at/rtr/rmbt/statisticServer/opendata/dto/LocationGraphDTO.java
@@ -3,6 +3,7 @@ package at.rtr.rmbt.statisticServer.opendata.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModelProperty;
 
 import java.util.ArrayList;
 import java.util.Date;
@@ -44,6 +45,8 @@ public class LocationGraphDTO {
         private Double altitude;
         private String provider;
 
+        @ApiModelProperty(value = "Direction of travel of the hosting device in degrees, where 0° ≤ bearing < 360°, counting clockwise relative to the true north",
+                example = "195.4")
         public Double getBearing() {
             if (getProvider().equals("gps")) {
                 return bearing;
@@ -51,6 +54,8 @@ public class LocationGraphDTO {
             return null;
         }
 
+        @ApiModelProperty(value = "Speed of the client device in meters per second",
+                example = "22.4")
         public Double getSpeed() {
             if (getProvider().equals("gps")) {
                 return speed;
@@ -60,6 +65,8 @@ public class LocationGraphDTO {
 
 
         @JsonProperty("long")
+        @ApiModelProperty(value = "Longitude of the client position.",
+                example = "14.20882799")
         public double getLongitude() {
             return longitude;
         }
@@ -69,6 +76,8 @@ public class LocationGraphDTO {
         }
 
         @JsonProperty("lat")
+        @ApiModelProperty(value = "Latitude of the client position.",
+                example = "47.76077786")
         public double getLatitude() {
             return latitude;
         }
@@ -78,6 +87,8 @@ public class LocationGraphDTO {
         }
 
         @JsonProperty("loc_accuracy")
+        @ApiModelProperty(value = "Estimation of accuracy of client location.",
+                example = "8")
         public Double getLocAccuracy() {
             if (locAccuracy > 0) {
                 return locAccuracy;
@@ -89,6 +100,9 @@ public class LocationGraphDTO {
             this.locAccuracy = locAccuracy;
         }
 
+        @JsonProperty("time_elapsed")
+        @ApiModelProperty(value = "The time elapsed since the start of the test in milliseconds.",
+                example = "55")
         public long getTimeElapsed() {
             return timeElapsed;
         }
@@ -109,6 +123,8 @@ public class LocationGraphDTO {
         }
 
         @JsonProperty("loc_src")
+        @ApiModelProperty(value = "Source for the geo location-data. Values: “gps”, “network”.",
+                example = "gps")
         public String getProvider() {
             return provider;
         }

--- a/RMBTStatisticServer/src/at/rtr/rmbt/statisticServer/opendata/dto/LocationGraphDTO.java
+++ b/RMBTStatisticServer/src/at/rtr/rmbt/statisticServer/opendata/dto/LocationGraphDTO.java
@@ -111,8 +111,9 @@ public class LocationGraphDTO {
             this.timeElapsed = timeElapsed;
         }
 
+        @ApiModelProperty(value="Altitude of the client position in meters", example = "300.4")
         public Double getAltitude() {
-            if (altitude == null && altitude != 0) {
+            if (altitude != null && altitude != 0) {
                 return altitude;
             }
             return null;

--- a/RMBTStatisticServer/src/at/rtr/rmbt/statisticServer/opendata/dto/LocationGraphDTO.java
+++ b/RMBTStatisticServer/src/at/rtr/rmbt/statisticServer/opendata/dto/LocationGraphDTO.java
@@ -1,0 +1,130 @@
+package at.rtr.rmbt.statisticServer.opendata.dto;
+
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+public class LocationGraphDTO {
+    private double totalDistance;
+    private List<LocationGraphItem> locations = new ArrayList<>();
+
+
+    public double getTotalDistance() {
+        return totalDistance;
+    }
+
+    public void setTotalDistance(double totalDistance) {
+        this.totalDistance = totalDistance;
+    }
+
+    public List<LocationGraphItem> getLocations() {
+        return locations;
+    }
+
+    public void addLocation(LocationGraphItem location) {
+        this.getLocations().add(location);
+    }
+
+    public void setLocations(List<LocationGraphItem> locations) {
+        this.locations = locations;
+    }
+
+    public static class LocationGraphItem {
+        private Double longitude;
+        private Double latitude;
+        private Double locAccuracy;
+        private long timeElapsed;
+        private Date time;
+        private Double bearing;
+        private Double speed;
+        private Double altitude;
+        private String provider;
+
+        public Double getBearing() {
+            if (getProvider().equals("gps")) {
+                return bearing;
+            }
+            return null;
+        }
+
+        public Double getSpeed() {
+            if (getProvider().equals("gps")) {
+                return speed;
+            }
+            return null;
+        }
+
+
+        @JsonProperty("long")
+        public double getLongitude() {
+            return longitude;
+        }
+
+        public void setLongitude(double longitude) {
+            this.longitude = longitude;
+        }
+
+        @JsonProperty("lat")
+        public double getLatitude() {
+            return latitude;
+        }
+
+        public void setLatitude(double latitude) {
+            this.latitude = latitude;
+        }
+
+        @JsonProperty("loc_accuracy")
+        public Double getLocAccuracy() {
+            if (locAccuracy > 0) {
+                return locAccuracy;
+            }
+            return null;
+        }
+
+        public void setLocAccuracy(Double locAccuracy) {
+            this.locAccuracy = locAccuracy;
+        }
+
+        public long getTimeElapsed() {
+            return timeElapsed;
+        }
+
+        public void setTimeElapsed(long timeElapsed) {
+            this.timeElapsed = timeElapsed;
+        }
+
+        public Double getAltitude() {
+            if (altitude == null && altitude != 0) {
+                return altitude;
+            }
+            return null;
+        }
+
+        public void setAltitude(Double altitude) {
+            this.altitude = altitude;
+        }
+
+        @JsonProperty("loc_src")
+        public String getProvider() {
+            return provider;
+        }
+
+        public void setProvider(String provider) {
+            this.provider = provider;
+        }
+
+
+        @JsonIgnore
+        public Date getTime() {
+            return time;
+        }
+
+        public void setTime(Date time) {
+            this.time = time;
+        }
+    }
+}

--- a/RMBTStatisticServer/src/at/rtr/rmbt/statisticServer/opendata/dto/OpenTestDTO.java
+++ b/RMBTStatisticServer/src/at/rtr/rmbt/statisticServer/opendata/dto/OpenTestDTO.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.swagger.annotations.ApiModelProperty;
 
 //JSON property order for CSV output
 @JsonPropertyOrder({"open_uuid", "open_test_uuid", "time", "lat", "long",
@@ -33,6 +34,9 @@ public class OpenTestDTO {
     private Integer pingClassification;
 
 
+    @JsonProperty("open_uuid")
+    @ApiModelProperty(value = "Open UUID identifying a test",
+            example = "P9f2b7bb1-39ea-454e-aa97-538564d7f8f1")
     public String getOpenUuid() {
         return openUuid;
     }
@@ -41,6 +45,9 @@ public class OpenTestDTO {
         this.openUuid = openUuid;
     }
 
+    @JsonProperty("open_test_uuid")
+    @ApiModelProperty(value = "Open UUID identifying a user",
+            example = "Oa1f286be-3c91-4f7d-b3d3-29d0e143e20d")
     public String getOpenTestUuid() {
         return openTestUuid;
     }
@@ -49,6 +56,10 @@ public class OpenTestDTO {
         this.openTestUuid = openTestUuid;
     }
 
+    @JsonProperty("time")
+    @ApiModelProperty(
+            example = "2018-07-15 01:55"
+    )
     public String getTime() {
         return time;
     }
@@ -57,6 +68,11 @@ public class OpenTestDTO {
         this.time = time;
     }
 
+    @JsonProperty("loc_accuracy")
+    @ApiModelProperty(
+            value = "Estimation of accuracy of client location in meters",
+            example = "15.28"
+    )
     public Double getLocAccuracy() {
         return locAccuracy;
     }
@@ -65,6 +81,11 @@ public class OpenTestDTO {
         this.locAccuracy = locAccuracy;
     }
 
+    @JsonProperty("download_kbit")
+    @ApiModelProperty(
+            value = "Download speed in kilobit per second",
+            example = "6903"
+    )
     public Long getDownloadKbit() {
         return downloadKbit;
     }
@@ -73,6 +94,11 @@ public class OpenTestDTO {
         this.downloadKbit = downloadKbit;
     }
 
+    @JsonProperty("upload_kbit")
+    @ApiModelProperty(
+            value = "Upload speed in kilobit per second",
+            example = "1565"
+    )
     public Long getUploadKbit() {
         return uploadKbit;
     }
@@ -81,6 +107,12 @@ public class OpenTestDTO {
         this.uploadKbit = uploadKbit;
     }
 
+    @JsonProperty("ping_ms")
+    @ApiModelProperty(
+            value = "Median ping (round-trip time) in milliseconds, measured on the server side. " +
+                    "In previous versions (before June 3rd 2015) this was the minimum ping measured on the client side.",
+            example = "16.178334"
+    )
     public Double getPingMs() {
         return pingMs;
     }
@@ -89,6 +121,11 @@ public class OpenTestDTO {
         this.pingMs = pingMs;
     }
 
+    @JsonProperty("signal_strength")
+    @ApiModelProperty(
+            value = "Signal strength (RSSI) in dBm.",
+            example = "-56"
+    )
     public Integer getSignalStrength() {
         return signalStrength;
     }
@@ -97,6 +134,11 @@ public class OpenTestDTO {
         this.signalStrength = signalStrength;
     }
 
+    @JsonProperty("lte_rsrp")
+    @ApiModelProperty(
+            value = "LTE signal strength in dBm.",
+            example = "-81"
+    )
     public Integer getLteRsrp() {
         return lteRsrp;
     }
@@ -105,6 +147,16 @@ public class OpenTestDTO {
         this.lteRsrp = lteRsrp;
     }
 
+    @JsonProperty("platform")
+    @ApiModelProperty(
+            value = "Platform on which the test has been conducted. E.g.\n" +
+                    "* “Android” (= Google Android App),\n" +
+                    "* “iOS” (= Apple iOs App),\n" +
+                    "* Applet (= Java applet test within a browser),\n" +
+                    "* RMBTjs (= simple JavaScript test within a browser, without Java),\n" +
+                    "* RMBTws (= advanced JavaScript test using WebSockets within the browser).\n",
+            example = "RMBTws"
+    )
     public String getPlatform() {
         return platform;
     }
@@ -113,6 +165,11 @@ public class OpenTestDTO {
         this.platform = platform;
     }
 
+    @JsonProperty("model")
+    @ApiModelProperty(
+            value = "Name of the device used.",
+            example = "Sony Xperia Tablet Z LTE"
+    )
     public String getModel() {
         return model;
     }
@@ -121,6 +178,11 @@ public class OpenTestDTO {
         this.model = model;
     }
 
+    @JsonProperty("provider_name")
+    @ApiModelProperty(
+            value = "Name of the internet service provider.",
+            example = "Provider"
+    )
     public String getProviderName() {
         return providerName;
     }
@@ -138,7 +200,13 @@ public class OpenTestDTO {
         this.cursor = cursor;
     }
 
+    @JsonProperty("download_classification")
     @JsonInclude(JsonInclude.Include.NON_NULL)
+    @ApiModelProperty(
+            value = "Classification for the download speed in a traffic-light system.\n\n" +
+                    "0 = unknown, 1 = red, 2 = yellow, 3 = green.",
+            example = "2"
+    )
     public Integer getDownloadClassification() {
         return downloadClassification;
     }
@@ -147,7 +215,13 @@ public class OpenTestDTO {
         this.downloadClassification = downloadClassification;
     }
 
+    @JsonProperty("upload_classification")
     @JsonInclude(JsonInclude.Include.NON_NULL)
+    @ApiModelProperty(
+            value = "Classification for the upload speed in a traffic-light system.\n\n" +
+                    "0 = unknown, 1 = red, 2 = yellow, 3 = green.",
+            example = "1"
+    )
     public Integer getUploadClassification() {
         return uploadClassification;
     }
@@ -156,7 +230,13 @@ public class OpenTestDTO {
         this.uploadClassification = uploadClassification;
     }
 
+    @JsonProperty("ping_classification")
     @JsonInclude(JsonInclude.Include.NON_NULL)
+    @ApiModelProperty(
+            value = "Classification for the ping speed in a traffic-light system.\n\n" +
+                    "0 = unknown, 1 = red, 2 = yellow, 3 = green.",
+            example = "3"
+    )
     public Integer getPingClassification() {
         return pingClassification;
     }
@@ -166,6 +246,10 @@ public class OpenTestDTO {
     }
 
     @JsonProperty("lat")
+    @ApiModelProperty(
+            value = "Latitude of the client position.",
+            example = "48.2029024"
+    )
     public Double getLatitude() {
         return latitude;
     }
@@ -175,6 +259,10 @@ public class OpenTestDTO {
     }
 
     @JsonProperty("long")
+    @ApiModelProperty(
+            value = "Longitude of the client position.",
+            example = "16.3967841"
+    )
     public Double getLongitude() {
         return longitude;
     }

--- a/RMBTStatisticServer/src/at/rtr/rmbt/statisticServer/opendata/dto/OpenTestDTO.java
+++ b/RMBTStatisticServer/src/at/rtr/rmbt/statisticServer/opendata/dto/OpenTestDTO.java
@@ -1,0 +1,187 @@
+package at.rtr.rmbt.statisticServer.opendata.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+//JSON property order for CSV output
+@JsonPropertyOrder({"open_uuid", "open_test_uuid", "time", "lat", "long",
+        "download_kbit", "upload_kbit", "ping_ms", "signal_strength", "lte_rsrp",
+        "platform", "provider_name", "model", "loc_accuracy",
+        "download_classification", "upload_classification", "ping_classificatio"})
+public class OpenTestDTO {
+
+
+    private Long cursor;
+    private String openUuid;
+    private String openTestUuid;
+    private String time;
+    private Double latitude;
+    private Double longitude;
+    private Double locAccuracy;
+    private Long downloadKbit;
+    private Long uploadKbit;
+    private Double pingMs;
+    private Long signalStrength;
+    private Long lteRsrp;
+    private String platform;
+    private String model;
+    private String providerName;
+    private Integer downloadClassification;
+    private Integer uploadClassification;
+    private Integer pingClassification;
+
+
+    public String getOpenUuid() {
+        return openUuid;
+    }
+
+    public void setOpenUuid(String openUuid) {
+        this.openUuid = openUuid;
+    }
+
+    public String getOpenTestUuid() {
+        return openTestUuid;
+    }
+
+    public void setOpenTestUuid(String openTestUuid) {
+        this.openTestUuid = openTestUuid;
+    }
+
+    public String getTime() {
+        return time;
+    }
+
+    public void setTime(String time) {
+        this.time = time;
+    }
+
+    public Double getLocAccuracy() {
+        return locAccuracy;
+    }
+
+    public void setLocAccuracy(Double locAccuracy) {
+        this.locAccuracy = locAccuracy;
+    }
+
+    public Long getDownloadKbit() {
+        return downloadKbit;
+    }
+
+    public void setDownloadKbit(Long downloadKbit) {
+        this.downloadKbit = downloadKbit;
+    }
+
+    public Long getUploadKbit() {
+        return uploadKbit;
+    }
+
+    public void setUploadKbit(Long uploadKbit) {
+        this.uploadKbit = uploadKbit;
+    }
+
+    public Double getPingMs() {
+        return pingMs;
+    }
+
+    public void setPingMs(Double pingMs) {
+        this.pingMs = pingMs;
+    }
+
+    public Long getSignalStrength() {
+        return signalStrength;
+    }
+
+    public void setSignalStrength(Long signalStrength) {
+        this.signalStrength = signalStrength;
+    }
+
+    public Long getLteRsrp() {
+        return lteRsrp;
+    }
+
+    public void setLteRsrp(Long lteRsrp) {
+        this.lteRsrp = lteRsrp;
+    }
+
+    public String getPlatform() {
+        return platform;
+    }
+
+    public void setPlatform(String platform) {
+        this.platform = platform;
+    }
+
+    public String getModel() {
+        return model;
+    }
+
+    public void setModel(String model) {
+        this.model = model;
+    }
+
+    public String getProviderName() {
+        return providerName;
+    }
+
+    public void setProviderName(String providerName) {
+        this.providerName = providerName;
+    }
+
+    @JsonIgnore
+    public Long getCursor() {
+        return cursor;
+    }
+
+    public void setCursor(Long cursor) {
+        this.cursor = cursor;
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public Integer getDownloadClassification() {
+        return downloadClassification;
+    }
+
+    public void setDownloadClassification(Integer downloadClassification) {
+        this.downloadClassification = downloadClassification;
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public Integer getUploadClassification() {
+        return uploadClassification;
+    }
+
+    public void setUploadClassification(Integer uploadClassification) {
+        this.uploadClassification = uploadClassification;
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public Integer getPingClassification() {
+        return pingClassification;
+    }
+
+    public void setPingClassification(Integer pingClassification) {
+        this.pingClassification = pingClassification;
+    }
+
+    @JsonProperty("lat")
+    public Double getLatitude() {
+        return latitude;
+    }
+
+    public void setLatitude(Double latitude) {
+        this.latitude = latitude;
+    }
+
+    @JsonProperty("long")
+    public Double getLongitude() {
+        return longitude;
+    }
+
+    public void setLongitude(Double longitude) {
+        this.longitude = longitude;
+    }
+}
+
+

--- a/RMBTStatisticServer/src/at/rtr/rmbt/statisticServer/opendata/dto/OpenTestDTO.java
+++ b/RMBTStatisticServer/src/at/rtr/rmbt/statisticServer/opendata/dto/OpenTestDTO.java
@@ -23,8 +23,8 @@ public class OpenTestDTO {
     private Long downloadKbit;
     private Long uploadKbit;
     private Double pingMs;
-    private Long signalStrength;
-    private Long lteRsrp;
+    private Integer signalStrength;
+    private Integer lteRsrp;
     private String platform;
     private String model;
     private String providerName;
@@ -89,19 +89,19 @@ public class OpenTestDTO {
         this.pingMs = pingMs;
     }
 
-    public Long getSignalStrength() {
+    public Integer getSignalStrength() {
         return signalStrength;
     }
 
-    public void setSignalStrength(Long signalStrength) {
+    public void setSignalStrength(Integer signalStrength) {
         this.signalStrength = signalStrength;
     }
 
-    public Long getLteRsrp() {
+    public Integer getLteRsrp() {
         return lteRsrp;
     }
 
-    public void setLteRsrp(Long lteRsrp) {
+    public void setLteRsrp(Integer lteRsrp) {
         this.lteRsrp = lteRsrp;
     }
 

--- a/RMBTStatisticServer/src/at/rtr/rmbt/statisticServer/opendata/dto/OpenTestDetailsDTO.java
+++ b/RMBTStatisticServer/src/at/rtr/rmbt/statisticServer/opendata/dto/OpenTestDetailsDTO.java
@@ -1,6 +1,8 @@
 package at.rtr.rmbt.statisticServer.opendata.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModelProperty;
 
 import java.util.HashMap;
 import java.util.List;
@@ -75,10 +77,13 @@ public class OpenTestDetailsDTO extends OpenTestDTO {
     public String getError() {
         return error;
     }
+
     public void setError(String error) {
         this.error = error;
     }
 
+    @ApiModelProperty(value = "The distance that the user moved in meters.",
+            example = "134")
     public Double getDistance() {
         return distance;
     }
@@ -87,6 +92,9 @@ public class OpenTestDetailsDTO extends OpenTestDTO {
         this.distance = distance;
     }
 
+    @JsonProperty("cat_technology")
+    @ApiModelProperty(value = "Technology category of the network, e.g. “3G”, “4G”, “WLAN”.",
+            example = "4G")
     public String getCat_technology() {
         return cat_technology;
     }
@@ -95,6 +103,10 @@ public class OpenTestDetailsDTO extends OpenTestDTO {
         this.cat_technology = cat_technology;
     }
 
+    @JsonProperty("loc_src")
+    @ApiModelProperty(value = "Source for the geo location-data. Values: “gps”, “network”.",
+            example = "gps",
+            allowableValues = "gps,network")
     public String getLocSrc() {
         return locSrc;
     }
@@ -103,6 +115,9 @@ public class OpenTestDetailsDTO extends OpenTestDTO {
         this.locSrc = locSrc;
     }
 
+    @JsonProperty("public_ip_as_name")
+    @ApiModelProperty(value = "Name of the AS of the clients public IP.",
+            example = "AS32768 Provider")
     public String getPublicIpAsName() {
         return publicIpAsName;
     }
@@ -111,6 +126,8 @@ public class OpenTestDetailsDTO extends OpenTestDTO {
         this.publicIpAsName = publicIpAsName;
     }
 
+    @JsonProperty("zip_code")
+    @ApiModelProperty(value = "Obsolete, always 'null'")
     public Long getZipCode() {
         return zipCode;
     }
@@ -119,6 +136,9 @@ public class OpenTestDetailsDTO extends OpenTestDTO {
         this.zipCode = zipCode;
     }
 
+    @JsonProperty("kg_nr")
+    @ApiModelProperty(value = "Number of the cadastral community, see <http://www.bev.gv.at/portal/page?_pageid=713,2601287&_dad=portal&_schema=PORTAL>",
+            example = "1009")
     public Long getKgNr() {
         return kgNr;
     }
@@ -127,6 +147,9 @@ public class OpenTestDetailsDTO extends OpenTestDTO {
         this.kgNr = kgNr;
     }
 
+    @JsonProperty("gkz")
+    @ApiModelProperty(value = "Community ID (Gemeindekennzahl, see <http://www.bev.gv.at/portal/page?_pageid=713,2601287&_dad=portal&_schema=PORTAL>).",
+            example = "90001")
     public Long getGkz() {
         return gkz;
     }
@@ -135,6 +158,9 @@ public class OpenTestDetailsDTO extends OpenTestDTO {
         this.gkz = gkz;
     }
 
+    @JsonProperty("gkz_sa")
+    @ApiModelProperty(value = "Community ID (Gemeindekennzahl, see <http://www.statistik.at/web_de/klassifikationen/regionale_gliederungen/gemeinden/index.html>)",
+            example = "90601")
     public Long getGkzSa() {
         return gkzSa;
     }
@@ -143,6 +169,9 @@ public class OpenTestDetailsDTO extends OpenTestDTO {
         this.gkzSa = gkzSa;
     }
 
+    @JsonProperty("land_cover")
+    @ApiModelProperty(value = "Classification of the land cover within austria, see <http://www.umweltbundesamt.at/fileadmin/site/umweltthemen/raumplanung/1_flaechennutzung/corine/CORINE_Nomenklatur.pdf> and <https://www.eea.europa.eu/data-and-maps/data/clc-2006-vector-4>",
+            example = "112")
     public Long getLandCover() {
         return landCover;
     }
@@ -151,6 +180,9 @@ public class OpenTestDetailsDTO extends OpenTestDTO {
         this.landCover = landCover;
     }
 
+    @JsonProperty("locality")
+    @ApiModelProperty(value = "Name of the cadastral community, see: <http://www.bev.gv.at/portal/page?_pageid=713,2601287&_dad=portal&_schema=PORTAL>",
+            example = "Mariahilf")
     public String getLocality() {
         return locality;
     }
@@ -159,6 +191,9 @@ public class OpenTestDetailsDTO extends OpenTestDTO {
         this.locality = locality;
     }
 
+    @JsonProperty("community")
+    @ApiModelProperty(value = "Name of Austrian community (Gemeinde).",
+            example = "Wien")
     public String getCommunity() {
         return community;
     }
@@ -167,6 +202,9 @@ public class OpenTestDetailsDTO extends OpenTestDTO {
         this.community = community;
     }
 
+    @JsonProperty("district")
+    @ApiModelProperty(value = "Name of Austrian district (Bezirk).",
+            example = "Mistelbach")
     public String getDistrict() {
         return district;
     }
@@ -175,6 +213,9 @@ public class OpenTestDetailsDTO extends OpenTestDTO {
         this.district = district;
     }
 
+    @JsonProperty("province")
+    @ApiModelProperty(value = "Name of Austrian province (Bundesland)",
+            example = "Wien")
     public String getProvince() {
         return province;
     }
@@ -183,6 +224,9 @@ public class OpenTestDetailsDTO extends OpenTestDTO {
         this.province = province;
     }
 
+    @JsonProperty("lte_rsrp")
+    @ApiModelProperty(value = "LTE signal quality in decibels",
+            example = "-6")
     public Double getLteRsrq() {
         return lteRsrq;
     }
@@ -191,6 +235,9 @@ public class OpenTestDetailsDTO extends OpenTestDTO {
         this.lteRsrq = lteRsrq;
     }
 
+    @JsonProperty("server_name")
+    @ApiModelProperty(value = "Name of the test-server.",
+            example = "RTR-DEVELOP-SERVER")
     public String getServerName() {
         return serverName;
     }
@@ -199,6 +246,9 @@ public class OpenTestDetailsDTO extends OpenTestDTO {
         this.serverName = serverName;
     }
 
+    @JsonProperty("implausible")
+    @ApiModelProperty(value = "Identification of implausible test results.",
+            example = "true")
     public Boolean getImplausible() {
         return implausible;
     }
@@ -207,6 +257,8 @@ public class OpenTestDetailsDTO extends OpenTestDTO {
         this.implausible = implausible;
     }
 
+    @JsonProperty("pinned")
+    @ApiModelProperty(value = "_True_, if if the test is relevant for generating the statistics (e.g. not part of a series)")
     public Boolean getPinned() {
         return pinned;
     }
@@ -215,6 +267,9 @@ public class OpenTestDetailsDTO extends OpenTestDTO {
         this.pinned = pinned;
     }
 
+    @JsonProperty("test_duration")
+    @ApiModelProperty(value = "Duration of the test per direction (up- or download) in seconds.",
+            example = "7")
     public Long getTestDuration() {
         return testDuration;
     }
@@ -223,6 +278,9 @@ public class OpenTestDetailsDTO extends OpenTestDTO {
         this.testDuration = testDuration;
     }
 
+    @JsonProperty("num_threads_requested")
+    @ApiModelProperty(value = "Number of threads requested by the server.",
+            example = "3")
     public Long getNumThreadsRequested() {
         return numThreadsRequested;
     }
@@ -231,6 +289,9 @@ public class OpenTestDetailsDTO extends OpenTestDTO {
         this.numThreadsRequested = numThreadsRequested;
     }
 
+    @JsonProperty("num_threads")
+    @ApiModelProperty(value = "Number of threads used for the downlink test.",
+            example = "3")
     public Long getNumThreads() {
         return numThreads;
     }
@@ -239,6 +300,9 @@ public class OpenTestDetailsDTO extends OpenTestDTO {
         this.numThreads = numThreads;
     }
 
+    @JsonProperty("num_threads_ul")
+    @ApiModelProperty(value = "Number of threads used for the uplink test.",
+            example = "3")
     public Long getNumThreadsUl() {
         return numThreadsUl;
     }
@@ -247,6 +311,9 @@ public class OpenTestDetailsDTO extends OpenTestDTO {
         this.numThreadsUl = numThreadsUl;
     }
 
+    @JsonProperty("model")
+    @ApiModelProperty(value = "Name of the device used.",
+            example = "Sony Xperia Tablet Z LTE")
     public String getModel() {
         return model;
     }
@@ -255,6 +322,9 @@ public class OpenTestDetailsDTO extends OpenTestDTO {
         this.model = model;
     }
 
+    @JsonProperty("model_native")
+    @ApiModelProperty(value = "Name of the device used, raw device name.",
+            example = "SGP321")
     public String getModelNative() {
         return modelNative;
     }
@@ -263,6 +333,9 @@ public class OpenTestDetailsDTO extends OpenTestDTO {
         this.modelNative = modelNative;
     }
 
+    @JsonProperty("product")
+    @ApiModelProperty(value = "Name of the client device.",
+            example = "SGP321")
     public String getProduct() {
         return product;
     }
@@ -271,6 +344,9 @@ public class OpenTestDetailsDTO extends OpenTestDTO {
         this.product = product;
     }
 
+    @JsonProperty("client_version")
+    @ApiModelProperty(value = "Software version number of the client.",
+            example = "1.1")
     public String getClientVersion() {
         return clientVersion;
     }
@@ -279,6 +355,9 @@ public class OpenTestDetailsDTO extends OpenTestDTO {
         this.clientVersion = clientVersion;
     }
 
+    @JsonProperty("network_mcc_mnc")
+    @ApiModelProperty(value = "Network identification whereas the first three digits represent the country, the digits following the dash represent the mobile network provider within that country.",
+            example = "232-05")
     public String getNetworkMccMnc() {
         return networkMccMnc;
     }
@@ -287,6 +366,9 @@ public class OpenTestDetailsDTO extends OpenTestDTO {
         this.networkMccMnc = networkMccMnc;
     }
 
+    @JsonProperty("network_country")
+    @ApiModelProperty(value = "Country of the network in ISO 3166.",
+            example = "DE")
     public Long getNetworkCountry() {
         return networkCountry;
     }
@@ -295,6 +377,13 @@ public class OpenTestDetailsDTO extends OpenTestDTO {
         this.networkCountry = networkCountry;
     }
 
+    @JsonProperty("roaming_type")
+    @ApiModelProperty(value = "Integer representing the roaming status of the client:\n" +
+            "* 0: no roaming,\n" +
+            "* 1: national roaming,\n" +
+            "* 2: international roaming.",
+            example = "1",
+            allowableValues = "0,1,2")
     public Long getRoamingType() {
         return roamingType;
     }
@@ -303,6 +392,9 @@ public class OpenTestDetailsDTO extends OpenTestDTO {
         this.roamingType = roamingType;
     }
 
+    @JsonProperty("network_name")
+    @ApiModelProperty(value = "Display name of the mobile network.",
+            example = "3 AT")
     public String getNetworkName() {
         return networkName;
     }
@@ -311,6 +403,9 @@ public class OpenTestDetailsDTO extends OpenTestDTO {
         this.networkName = networkName;
     }
 
+    @JsonProperty("sim_mcc_mnc")
+    @ApiModelProperty(value = "Network identification of the SIM provider. The digits of MCC and MNC have the same meaning as described in “network_mcc_mnc”.",
+            example = "232-01")
     public String getSimMccMnc() {
         return simMccMnc;
     }
@@ -319,6 +414,9 @@ public class OpenTestDetailsDTO extends OpenTestDTO {
         this.simMccMnc = simMccMnc;
     }
 
+    @JsonProperty("sim_country")
+    @ApiModelProperty(value = "Home country of the SIM card in ISO 3166.",
+            example = "AT")
     public String getSimCountry() {
         return simCountry;
     }
@@ -327,6 +425,9 @@ public class OpenTestDetailsDTO extends OpenTestDTO {
         this.simCountry = simCountry;
     }
 
+    @JsonProperty("connection")
+    @ApiModelProperty(value = "Type of connection in terms of NAT and IP-Version (e.g. behind NAT with local to public IP and IPv4).",
+            example = "nat_local_to_public_ipv4")
     public String getConnection() {
         return connection;
     }
@@ -335,6 +436,9 @@ public class OpenTestDetailsDTO extends OpenTestDTO {
         this.connection = connection;
     }
 
+    @JsonProperty("asn")
+    @ApiModelProperty(value = "Autonomous system number.",
+            example = "6830")
     public Long getAsn() {
         return asn;
     }
@@ -343,6 +447,9 @@ public class OpenTestDetailsDTO extends OpenTestDTO {
         this.asn = asn;
     }
 
+    @JsonProperty("ip_anonym")
+    @ApiModelProperty(value = "The anonymized IP-Address of the client.",
+            example = "80.108.108")
     public String getIpAnonym() {
         return ipAnonym;
     }
@@ -351,6 +458,9 @@ public class OpenTestDetailsDTO extends OpenTestDTO {
         this.ipAnonym = ipAnonym;
     }
 
+    @JsonProperty("ndt_download_kbit")
+    @ApiModelProperty(value = "Download speed in the NDT-test in kilobit per second.",
+            example = "1443")
     public Double getNdtDownloadKbit() {
         return ndtDownloadKbit;
     }
@@ -359,6 +469,9 @@ public class OpenTestDetailsDTO extends OpenTestDTO {
         this.ndtDownloadKbit = ndtDownloadKbit;
     }
 
+    @JsonProperty("ndt_upload_kbit")
+    @ApiModelProperty(value = "Upload speed in the NDT-test in kilobit per second.",
+            example = "2334")
     public Double getNdtUploadKbit() {
         return ndtUploadKbit;
     }
@@ -367,6 +480,9 @@ public class OpenTestDetailsDTO extends OpenTestDTO {
         this.ndtUploadKbit = ndtUploadKbit;
     }
 
+    @JsonProperty("country_geoip")
+    @ApiModelProperty(value = "Country according client IP address.",
+            example = "HU")
     public String getCountryGeoip() {
         return countryGeoip;
     }
@@ -375,6 +491,9 @@ public class OpenTestDetailsDTO extends OpenTestDTO {
         this.countryGeoip = countryGeoip;
     }
 
+    @JsonProperty("country_asn")
+    @ApiModelProperty(value = "Country of AS of client IP.",
+            example = "FI")
     public String getCountryAsn() {
         return countryAsn;
     }
@@ -383,6 +502,9 @@ public class OpenTestDetailsDTO extends OpenTestDTO {
         this.countryAsn = countryAsn;
     }
 
+    @JsonProperty("bytes_download")
+    @ApiModelProperty(value = "Total number of bytes downloaded during download test (excluding training-phase).",
+            example = "13653343")
     public Long getBytesDownload() {
         return bytesDownload;
     }
@@ -391,6 +513,9 @@ public class OpenTestDetailsDTO extends OpenTestDTO {
         this.bytesDownload = bytesDownload;
     }
 
+    @JsonProperty("bytes_upload")
+    @ApiModelProperty(value = "Total number of bytes uploaded during upload test (excluding training-phase).",
+            example = "3712431")
     public Long getBytesUpload() {
         return bytesUpload;
     }
@@ -399,6 +524,9 @@ public class OpenTestDetailsDTO extends OpenTestDTO {
         this.bytesUpload = bytesUpload;
     }
 
+    @JsonProperty("test_if_bytes_download")
+    @ApiModelProperty(value = "Data volume received on the interface during the test (including training phase).",
+            example = "4991145")
     public Long getTestIfBytesDownload() {
         return testIfBytesDownload;
     }
@@ -407,6 +535,9 @@ public class OpenTestDetailsDTO extends OpenTestDTO {
         this.testIfBytesDownload = testIfBytesDownload;
     }
 
+    @JsonProperty("test_if_bytes_upload")
+    @ApiModelProperty(value = "Data volume transmitted on the interface during the test (including training phase).",
+            example = "1961967")
     public Long getTestIfBytesUpload() {
         return testIfBytesUpload;
     }
@@ -415,6 +546,9 @@ public class OpenTestDetailsDTO extends OpenTestDTO {
         this.testIfBytesUpload = testIfBytesUpload;
     }
 
+    @JsonProperty("testdl_if_bytes_download")
+    @ApiModelProperty(value = "Data volume received on the interface during the download test.",
+            example = "4580781")
     public Long getTestdlIfBytesDownload() {
         return testdlIfBytesDownload;
     }
@@ -423,6 +557,9 @@ public class OpenTestDetailsDTO extends OpenTestDTO {
         this.testdlIfBytesDownload = testdlIfBytesDownload;
     }
 
+    @JsonProperty("testdl_if_bytes_upload")
+    @ApiModelProperty(value = "Data volume transmitted on the interface during the download test.",
+            example = "107077")
     public Long getTestdlIfBytesUpload() {
         return testdlIfBytesUpload;
     }
@@ -431,6 +568,9 @@ public class OpenTestDetailsDTO extends OpenTestDTO {
         this.testdlIfBytesUpload = testdlIfBytesUpload;
     }
 
+    @JsonProperty("testul_if_bytes_download")
+    @ApiModelProperty(value = "Data volume received on the interface during the upload test.",
+            example = "57372")
     public Long getTestulIfBytesDownload() {
         return testulIfBytesDownload;
     }
@@ -439,6 +579,9 @@ public class OpenTestDetailsDTO extends OpenTestDTO {
         this.testulIfBytesDownload = testulIfBytesDownload;
     }
 
+    @JsonProperty("testul_if_bytes_upload")
+    @ApiModelProperty(value = "Data volume transmitted on the interface during the upload test.",
+            example = "1627790")
     public Long getTestulIfBytesUpload() {
         return testulIfBytesUpload;
     }
@@ -447,6 +590,9 @@ public class OpenTestDetailsDTO extends OpenTestDTO {
         this.testulIfBytesUpload = testulIfBytesUpload;
     }
 
+    @JsonProperty("duration_download_ms")
+    @ApiModelProperty(value = "Duration of download test in ms.",
+            example = "7000.13")
     public Double getDurationDownloadMs() {
         return durationDownloadMs;
     }
@@ -455,6 +601,9 @@ public class OpenTestDetailsDTO extends OpenTestDTO {
         this.durationDownloadMs = durationDownloadMs;
     }
 
+    @JsonProperty("duration_upload_ms")
+    @ApiModelProperty(value = "Duration of upload test in ms.",
+            example = "7000.11")
     public Double getDurationUploadMs() {
         return durationUploadMs;
     }
@@ -463,6 +612,9 @@ public class OpenTestDetailsDTO extends OpenTestDTO {
         this.durationUploadMs = durationUploadMs;
     }
 
+    @JsonProperty("time_dl_ms")
+    @ApiModelProperty(value = "Relative start time of download in ms.",
+            example = "3692.15")
     public Double getTimeDlMs() {
         return timeDlMs;
     }
@@ -471,6 +623,9 @@ public class OpenTestDetailsDTO extends OpenTestDTO {
         this.timeDlMs = timeDlMs;
     }
 
+    @JsonProperty("time_ul_ms")
+    @ApiModelProperty(value = "Relative start time of upload in ms.",
+            example = "13496.54")
     public Double getTimeUlMs() {
         return timeUlMs;
     }
@@ -479,6 +634,10 @@ public class OpenTestDetailsDTO extends OpenTestDTO {
         this.timeUlMs = timeUlMs;
     }
 
+    @JsonProperty("channel_number")
+    @ApiModelProperty(value = "Channel number of the radio channel used during a measurement. E.g. the 18-bit Absolute RF Channel Number (EARFCN) " +
+            "in case of 4G or the 16-bit UMTS Absolute RF Channel Number (UARFCN) in case of 3G.",
+            example = "397")
     public Long getChannelNumber() {
         return channelNumber;
     }
@@ -487,6 +646,9 @@ public class OpenTestDetailsDTO extends OpenTestDTO {
         this.channelNumber = channelNumber;
     }
 
+    @JsonProperty("radio_band")
+    @ApiModelProperty(value = "Radio band used when conducting the test.",
+            example = "20")
     public Long getRadioBand() {
         return radioBand;
     }
@@ -495,6 +657,9 @@ public class OpenTestDetailsDTO extends OpenTestDTO {
         this.radioBand = radioBand;
     }
 
+    @JsonProperty("cell_area_code")
+    @ApiModelProperty(value = "Number describing the coarse location of a cell. E.g. the Tracking Area Code (TAC) in case of 4G or the Location Area Code (LAC) in case of 2G or 3G",
+            example = "10156")
     public Long getCellAreaCode() {
         return cellAreaCode;
     }
@@ -503,6 +668,9 @@ public class OpenTestDetailsDTO extends OpenTestDTO {
         this.cellAreaCode = cellAreaCode;
     }
 
+    @JsonProperty("network_type")
+    @ApiModelProperty(value = "Type of the network, e.g. MOBILE, LAN, WLAN.",
+            example = "WLAN")
     public String getNetworkType() {
         return networkType;
     }
@@ -511,6 +679,9 @@ public class OpenTestDetailsDTO extends OpenTestDTO {
         this.networkType = networkType;
     }
 
+    @JsonProperty("signal_classification")
+    @ApiModelProperty(value = "Classification for the signal strength in a traffic-light system.",
+            example = "2")
     public Integer getSignalClassification() {
         return signalClassification;
     }
@@ -519,6 +690,8 @@ public class OpenTestDetailsDTO extends OpenTestDTO {
         this.signalClassification = signalClassification;
     }
 
+    @JsonProperty("speed_curve")
+    @ApiModelProperty(value = "Aggregated history of transferred data bytes during a test.")
     public OpenTestGraphDTO getSpeedCurve() {
         return speedCurve;
     }
@@ -527,6 +700,9 @@ public class OpenTestDetailsDTO extends OpenTestDTO {
         this.speedCurve = speedCurve;
     }
 
+    @JsonProperty("country_location")
+    @ApiModelProperty(value = "Country of geo-location.",
+            example = "FR")
     public String getCountryLocation() {
         return countryLocation;
     }
@@ -535,6 +711,10 @@ public class OpenTestDetailsDTO extends OpenTestDTO {
         this.countryLocation = countryLocation;
     }
 
+    @JsonProperty("cell_location_id")
+    @ApiModelProperty(value = "Number identifying the location of a cell. E.g. the 28-bit Cell Identity (CI) in case of 4G, the 28-bit UMTS Cell Identity (CID) in case of UMTS " +
+            "or the 16-bit GSM Cell Identity (CID) in case of GSM.",
+            example = "28708964")
     public Long getCellLocationId() {
         return cellLocationId;
     }
@@ -543,7 +723,9 @@ public class OpenTestDetailsDTO extends OpenTestDTO {
         this.cellLocationId = cellLocationId;
     }
 
+    @JsonProperty("speed_curve_threadwise")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @ApiModelProperty(value = "History of transferred data bytes per thread during a test. Returned only if verbose>0.")
     public Map<String, Map<String, List<SpeedGraphItemDTO.SpeedItemThreadwise>>> getSpeedCurveThreadwise() {
         return speedCurveThreadwise;
     }
@@ -552,6 +734,9 @@ public class OpenTestDetailsDTO extends OpenTestDTO {
         this.speedCurveThreadwise = speedCurveThreadwise;
     }
 
+    @JsonProperty("wifi_link_speed")
+    @ApiModelProperty(value = "WLAN link speed according to the Android API.",
+            example = "7562")
     public Double getWifiLinkSpeed() {
         return wifiLinkSpeed;
     }

--- a/RMBTStatisticServer/src/at/rtr/rmbt/statisticServer/opendata/dto/OpenTestDetailsDTO.java
+++ b/RMBTStatisticServer/src/at/rtr/rmbt/statisticServer/opendata/dto/OpenTestDetailsDTO.java
@@ -1,0 +1,562 @@
+package at.rtr.rmbt.statisticServer.opendata.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class OpenTestDetailsDTO extends OpenTestDTO {
+
+    private Double distance;
+    private String cat_technology;
+    private String networkType;
+    private String locSrc;
+    private String publicIpAsName;
+    private Long zipCode;
+    private Long kgNr;
+    private Long gkz;
+    private Long gkzSa;
+    private Long landCover;
+    private String locality;
+    private String community;
+    private String district;
+    private String province;
+    private Double lteRsrq;
+    private String serverName;
+    private Boolean implausible;
+    private Boolean pinned;
+    private Long testDuration;
+    private Long numThreadsRequested;
+    private Long numThreads;
+    private Long numThreadsUl;
+    private String model;
+    private String modelNative;
+    private String product;
+    private String clientVersion;
+    private String networkMccMnc;
+    private Long networkCountry;
+    private Long roamingType;
+    private String networkName;
+    private String simMccMnc;
+    private String simCountry;
+    private String connection;
+    private Long asn;
+    private String ipAnonym;
+    private Double ndtDownloadKbit;
+    private Double ndtUploadKbit;
+    private String countryGeoip;
+    private String countryAsn;
+    private String countryLocation;
+    private Long bytesDownload;
+    private Long bytesUpload;
+    private Long testIfBytesDownload;
+    private Long testIfBytesUpload;
+    private Long testdlIfBytesDownload;
+    private Long testdlIfBytesUpload;
+    private Long testulIfBytesDownload;
+    private Long testulIfBytesUpload;
+    private Double durationDownloadMs;
+    private Double durationUploadMs;
+    private Double timeDlMs;
+    private Double timeUlMs;
+    private Long channelNumber;
+    private Long radioBand;
+    private Long cellAreaCode;
+    private Long cellLocationId;
+    private Integer signalClassification;
+    private String error;
+    private Double wifiLinkSpeed;
+
+    private OpenTestGraphDTO speedCurve;
+    private Map<String, Map<String, List<SpeedGraphItemDTO.SpeedItemThreadwise>>> speedCurveThreadwise = new HashMap<>();
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public String getError() {
+        return error;
+    }
+    public void setError(String error) {
+        this.error = error;
+    }
+
+    public Double getDistance() {
+        return distance;
+    }
+
+    public void setDistance(Double distance) {
+        this.distance = distance;
+    }
+
+    public String getCat_technology() {
+        return cat_technology;
+    }
+
+    public void setCat_technology(String cat_technology) {
+        this.cat_technology = cat_technology;
+    }
+
+    public String getLocSrc() {
+        return locSrc;
+    }
+
+    public void setLocSrc(String locSrc) {
+        this.locSrc = locSrc;
+    }
+
+    public String getPublicIpAsName() {
+        return publicIpAsName;
+    }
+
+    public void setPublicIpAsName(String publicIpAsName) {
+        this.publicIpAsName = publicIpAsName;
+    }
+
+    public Long getZipCode() {
+        return zipCode;
+    }
+
+    public void setZipCode(Long zipCode) {
+        this.zipCode = zipCode;
+    }
+
+    public Long getKgNr() {
+        return kgNr;
+    }
+
+    public void setKgNr(Long kgNr) {
+        this.kgNr = kgNr;
+    }
+
+    public Long getGkz() {
+        return gkz;
+    }
+
+    public void setGkz(Long gkz) {
+        this.gkz = gkz;
+    }
+
+    public Long getGkzSa() {
+        return gkzSa;
+    }
+
+    public void setGkzSa(Long gkzSa) {
+        this.gkzSa = gkzSa;
+    }
+
+    public Long getLandCover() {
+        return landCover;
+    }
+
+    public void setLandCover(Long landCover) {
+        this.landCover = landCover;
+    }
+
+    public String getLocality() {
+        return locality;
+    }
+
+    public void setLocality(String locality) {
+        this.locality = locality;
+    }
+
+    public String getCommunity() {
+        return community;
+    }
+
+    public void setCommunity(String community) {
+        this.community = community;
+    }
+
+    public String getDistrict() {
+        return district;
+    }
+
+    public void setDistrict(String district) {
+        this.district = district;
+    }
+
+    public String getProvince() {
+        return province;
+    }
+
+    public void setProvince(String province) {
+        this.province = province;
+    }
+
+    public Double getLteRsrq() {
+        return lteRsrq;
+    }
+
+    public void setLteRsrq(Double lteRsrq) {
+        this.lteRsrq = lteRsrq;
+    }
+
+    public String getServerName() {
+        return serverName;
+    }
+
+    public void setServerName(String serverName) {
+        this.serverName = serverName;
+    }
+
+    public Boolean getImplausible() {
+        return implausible;
+    }
+
+    public void setImplausible(Boolean implausible) {
+        this.implausible = implausible;
+    }
+
+    public Boolean getPinned() {
+        return pinned;
+    }
+
+    public void setPinned(Boolean pinned) {
+        this.pinned = pinned;
+    }
+
+    public Long getTestDuration() {
+        return testDuration;
+    }
+
+    public void setTestDuration(Long testDuration) {
+        this.testDuration = testDuration;
+    }
+
+    public Long getNumThreadsRequested() {
+        return numThreadsRequested;
+    }
+
+    public void setNumThreadsRequested(Long numThreadsRequested) {
+        this.numThreadsRequested = numThreadsRequested;
+    }
+
+    public Long getNumThreads() {
+        return numThreads;
+    }
+
+    public void setNumThreads(Long numThreads) {
+        this.numThreads = numThreads;
+    }
+
+    public Long getNumThreadsUl() {
+        return numThreadsUl;
+    }
+
+    public void setNumThreadsUl(Long numThreadsUl) {
+        this.numThreadsUl = numThreadsUl;
+    }
+
+    public String getModel() {
+        return model;
+    }
+
+    public void setModel(String model) {
+        this.model = model;
+    }
+
+    public String getModelNative() {
+        return modelNative;
+    }
+
+    public void setModelNative(String modelNative) {
+        this.modelNative = modelNative;
+    }
+
+    public String getProduct() {
+        return product;
+    }
+
+    public void setProduct(String product) {
+        this.product = product;
+    }
+
+    public String getClientVersion() {
+        return clientVersion;
+    }
+
+    public void setClientVersion(String clientVersion) {
+        this.clientVersion = clientVersion;
+    }
+
+    public String getNetworkMccMnc() {
+        return networkMccMnc;
+    }
+
+    public void setNetworkMccMnc(String networkMccMnc) {
+        this.networkMccMnc = networkMccMnc;
+    }
+
+    public Long getNetworkCountry() {
+        return networkCountry;
+    }
+
+    public void setNetworkCountry(Long networkCountry) {
+        this.networkCountry = networkCountry;
+    }
+
+    public Long getRoamingType() {
+        return roamingType;
+    }
+
+    public void setRoamingType(Long roamingType) {
+        this.roamingType = roamingType;
+    }
+
+    public String getNetworkName() {
+        return networkName;
+    }
+
+    public void setNetworkName(String networkName) {
+        this.networkName = networkName;
+    }
+
+    public String getSimMccMnc() {
+        return simMccMnc;
+    }
+
+    public void setSimMccMnc(String simMccMnc) {
+        this.simMccMnc = simMccMnc;
+    }
+
+    public String getSimCountry() {
+        return simCountry;
+    }
+
+    public void setSimCountry(String simCountry) {
+        this.simCountry = simCountry;
+    }
+
+    public String getConnection() {
+        return connection;
+    }
+
+    public void setConnection(String connection) {
+        this.connection = connection;
+    }
+
+    public Long getAsn() {
+        return asn;
+    }
+
+    public void setAsn(Long asn) {
+        this.asn = asn;
+    }
+
+    public String getIpAnonym() {
+        return ipAnonym;
+    }
+
+    public void setIpAnonym(String ipAnonym) {
+        this.ipAnonym = ipAnonym;
+    }
+
+    public Double getNdtDownloadKbit() {
+        return ndtDownloadKbit;
+    }
+
+    public void setNdtDownloadKbit(Double ndtDownloadKbit) {
+        this.ndtDownloadKbit = ndtDownloadKbit;
+    }
+
+    public Double getNdtUploadKbit() {
+        return ndtUploadKbit;
+    }
+
+    public void setNdtUploadKbit(Double ndtUploadKbit) {
+        this.ndtUploadKbit = ndtUploadKbit;
+    }
+
+    public String getCountryGeoip() {
+        return countryGeoip;
+    }
+
+    public void setCountryGeoip(String countryGeoip) {
+        this.countryGeoip = countryGeoip;
+    }
+
+    public String getCountryAsn() {
+        return countryAsn;
+    }
+
+    public void setCountryAsn(String countryAsn) {
+        this.countryAsn = countryAsn;
+    }
+
+    public Long getBytesDownload() {
+        return bytesDownload;
+    }
+
+    public void setBytesDownload(Long bytesDownload) {
+        this.bytesDownload = bytesDownload;
+    }
+
+    public Long getBytesUpload() {
+        return bytesUpload;
+    }
+
+    public void setBytesUpload(Long bytesUpload) {
+        this.bytesUpload = bytesUpload;
+    }
+
+    public Long getTestIfBytesDownload() {
+        return testIfBytesDownload;
+    }
+
+    public void setTestIfBytesDownload(Long testIfBytesDownload) {
+        this.testIfBytesDownload = testIfBytesDownload;
+    }
+
+    public Long getTestIfBytesUpload() {
+        return testIfBytesUpload;
+    }
+
+    public void setTestIfBytesUpload(Long testIfBytesUpload) {
+        this.testIfBytesUpload = testIfBytesUpload;
+    }
+
+    public Long getTestdlIfBytesDownload() {
+        return testdlIfBytesDownload;
+    }
+
+    public void setTestdlIfBytesDownload(Long testdlIfBytesDownload) {
+        this.testdlIfBytesDownload = testdlIfBytesDownload;
+    }
+
+    public Long getTestdlIfBytesUpload() {
+        return testdlIfBytesUpload;
+    }
+
+    public void setTestdlIfBytesUpload(Long testdlIfBytesUpload) {
+        this.testdlIfBytesUpload = testdlIfBytesUpload;
+    }
+
+    public Long getTestulIfBytesDownload() {
+        return testulIfBytesDownload;
+    }
+
+    public void setTestulIfBytesDownload(Long testulIfBytesDownload) {
+        this.testulIfBytesDownload = testulIfBytesDownload;
+    }
+
+    public Long getTestulIfBytesUpload() {
+        return testulIfBytesUpload;
+    }
+
+    public void setTestulIfBytesUpload(Long testulIfBytesUpload) {
+        this.testulIfBytesUpload = testulIfBytesUpload;
+    }
+
+    public Double getDurationDownloadMs() {
+        return durationDownloadMs;
+    }
+
+    public void setDurationDownloadMs(Double durationDownloadMs) {
+        this.durationDownloadMs = durationDownloadMs;
+    }
+
+    public Double getDurationUploadMs() {
+        return durationUploadMs;
+    }
+
+    public void setDurationUploadMs(Double durationUploadMs) {
+        this.durationUploadMs = durationUploadMs;
+    }
+
+    public Double getTimeDlMs() {
+        return timeDlMs;
+    }
+
+    public void setTimeDlMs(Double timeDlMs) {
+        this.timeDlMs = timeDlMs;
+    }
+
+    public Double getTimeUlMs() {
+        return timeUlMs;
+    }
+
+    public void setTimeUlMs(Double timeUlMs) {
+        this.timeUlMs = timeUlMs;
+    }
+
+    public Long getChannelNumber() {
+        return channelNumber;
+    }
+
+    public void setChannelNumber(Long channelNumber) {
+        this.channelNumber = channelNumber;
+    }
+
+    public Long getRadioBand() {
+        return radioBand;
+    }
+
+    public void setRadioBand(Long radioBand) {
+        this.radioBand = radioBand;
+    }
+
+    public Long getCellAreaCode() {
+        return cellAreaCode;
+    }
+
+    public void setCellAreaCode(Long cellAreaCode) {
+        this.cellAreaCode = cellAreaCode;
+    }
+
+    public String getNetworkType() {
+        return networkType;
+    }
+
+    public void setNetworkType(String networkType) {
+        this.networkType = networkType;
+    }
+
+    public Integer getSignalClassification() {
+        return signalClassification;
+    }
+
+    public void setSignalClassification(Integer signalClassification) {
+        this.signalClassification = signalClassification;
+    }
+
+    public OpenTestGraphDTO getSpeedCurve() {
+        return speedCurve;
+    }
+
+    public void setSpeedCurve(OpenTestGraphDTO speedCurve) {
+        this.speedCurve = speedCurve;
+    }
+
+    public String getCountryLocation() {
+        return countryLocation;
+    }
+
+    public void setCountryLocation(String countryLocation) {
+        this.countryLocation = countryLocation;
+    }
+
+    public Long getCellLocationId() {
+        return cellLocationId;
+    }
+
+    public void setCellLocationId(Long cellLocationId) {
+        this.cellLocationId = cellLocationId;
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public Map<String, Map<String, List<SpeedGraphItemDTO.SpeedItemThreadwise>>> getSpeedCurveThreadwise() {
+        return speedCurveThreadwise;
+    }
+
+    public void setSpeedCurveThreadwise(Map<String, Map<String, List<SpeedGraphItemDTO.SpeedItemThreadwise>>> speedCurveThreadwise) {
+        this.speedCurveThreadwise = speedCurveThreadwise;
+    }
+
+    public Double getWifiLinkSpeed() {
+        return wifiLinkSpeed;
+    }
+
+    public void setWifiLinkSpeed(Double wifiLinkSpeed) {
+        this.wifiLinkSpeed = wifiLinkSpeed;
+    }
+}

--- a/RMBTStatisticServer/src/at/rtr/rmbt/statisticServer/opendata/dto/OpenTestDetailsDTO.java
+++ b/RMBTStatisticServer/src/at/rtr/rmbt/statisticServer/opendata/dto/OpenTestDetailsDTO.java
@@ -224,7 +224,7 @@ public class OpenTestDetailsDTO extends OpenTestDTO {
         this.province = province;
     }
 
-    @JsonProperty("lte_rsrp")
+    @JsonProperty("lte_rsrq")
     @ApiModelProperty(value = "LTE signal quality in decibels",
             example = "-6")
     public Double getLteRsrq() {

--- a/RMBTStatisticServer/src/at/rtr/rmbt/statisticServer/opendata/dto/OpenTestExportDTO.java
+++ b/RMBTStatisticServer/src/at/rtr/rmbt/statisticServer/opendata/dto/OpenTestExportDTO.java
@@ -1,0 +1,310 @@
+package at.rtr.rmbt.statisticServer.opendata.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+//JSON property order for CSV output
+@JsonPropertyOrder({"open_uuid", "open_test_uuid", "time_utc", "cat_technology", "network_type", "lat", "long",
+        "loc_src", "loc_accuracy", "gkz", "zip_code", "country_location", "download_kbit", "upload_kbit", "ping_ms",
+        "lte_rsrp", "lte_rsrq", "server_name", "test_duration", "num_threads", "platform", "model", "client_version",
+        "network_mcc_mnc", "network_name", "sim_mcc_mnc", "nat_type", "asn", "ip_anonym", "ndt_download_kbit",
+        "ndt_upload_kbit", "implausible", "signal_strength", "pinned", "kg_nr", "gkz_sa", "land_cover", "cell_area_code",
+        "cell_location_id", "channel_number", "radio_band"})
+public class OpenTestExportDTO extends OpenTestDTO {
+
+
+    private String locSrc;
+
+    private Integer gkz;
+
+    private Integer zipCode;
+
+    private String countryLocation;
+
+    private String serverName;
+    private Integer testDuration;
+    private Integer numThreads;
+
+    private String clientVersion;
+    private String networkMccMnc;
+    private String networkName;
+    private String simMccMnc;
+    private String natType;
+    private Integer asn;
+    private String ipAnonym;
+
+    private Integer ndtDownloadKbit;
+    private Integer ndtUploadKbit;
+    private Boolean implausible;
+
+    private Boolean pinned;
+    private Integer kgNr;
+    private Integer gkzSa;
+    private Integer landCover;
+    private Integer cellAreaCode;
+    private Integer cellLocationId;
+    private Integer channelNumber;
+    private Integer radioBand;
+    private Integer lteRsrq;
+
+    private String catTechnology;
+
+    private String networkType;
+
+
+    @Override
+    @JsonProperty("time_utc")
+    public String getTime() {
+        return super.getTime();
+    }
+
+    @Override
+    @JsonIgnore
+    public Integer getDownloadClassification() {
+        return super.getDownloadClassification();
+    }
+
+    @Override
+    @JsonIgnore
+    public Integer getUploadClassification() {
+        return super.getUploadClassification();
+    }
+
+    @Override
+    @JsonIgnore
+    public Integer getPingClassification() {
+        return super.getPingClassification();
+    }
+
+    @Override
+    @JsonIgnore
+    public String getProviderName() {
+        return super.getProviderName();
+    }
+
+
+    public String getLocSrc() {
+        return locSrc;
+    }
+
+    public void setLocSrc(String locSrc) {
+        this.locSrc = locSrc;
+    }
+
+    public Integer getGkz() {
+        return gkz;
+    }
+
+    public void setGkz(Integer gkz) {
+        this.gkz = gkz;
+    }
+
+    public Integer getZipCode() {
+        return zipCode;
+    }
+
+    public void setZipCode(Integer zipCode) {
+        this.zipCode = zipCode;
+    }
+
+    public String getCountryLocation() {
+        return countryLocation;
+    }
+
+    public void setCountryLocation(String countryLocation) {
+        this.countryLocation = countryLocation;
+    }
+
+    public String getServerName() {
+        return serverName;
+    }
+
+    public void setServerName(String serverName) {
+        this.serverName = serverName;
+    }
+
+    public Integer getTestDuration() {
+        return testDuration;
+    }
+
+    public void setTestDuration(Integer testDuration) {
+        this.testDuration = testDuration;
+    }
+
+    public Integer getNumThreads() {
+        return numThreads;
+    }
+
+    public void setNumThreads(Integer numThreads) {
+        this.numThreads = numThreads;
+    }
+
+    public String getClientVersion() {
+        return clientVersion;
+    }
+
+    public void setClientVersion(String clientVersion) {
+        this.clientVersion = clientVersion;
+    }
+
+    public String getNetworkMccMnc() {
+        return networkMccMnc;
+    }
+
+    public void setNetworkMccMnc(String networkMccMnc) {
+        this.networkMccMnc = networkMccMnc;
+    }
+
+    public String getNetworkName() {
+        return networkName;
+    }
+
+    public void setNetworkName(String networkName) {
+        this.networkName = networkName;
+    }
+
+    public String getSimMccMnc() {
+        return simMccMnc;
+    }
+
+    public void setSimMccMnc(String simMccMnc) {
+        this.simMccMnc = simMccMnc;
+    }
+
+    public String getNatType() {
+        return natType;
+    }
+
+    public void setNatType(String natType) {
+        this.natType = natType;
+    }
+
+    public Integer getAsn() {
+        return asn;
+    }
+
+    public void setAsn(Integer asn) {
+        this.asn = asn;
+    }
+
+    public String getIpAnonym() {
+        return ipAnonym;
+    }
+
+    public void setIpAnonym(String ipAnonym) {
+        this.ipAnonym = ipAnonym;
+    }
+
+    public Integer getNdtDownloadKbit() {
+        return ndtDownloadKbit;
+    }
+
+    public void setNdtDownloadKbit(Integer ndtDownloadKbit) {
+        this.ndtDownloadKbit = ndtDownloadKbit;
+    }
+
+    public Integer getNdtUploadKbit() {
+        return ndtUploadKbit;
+    }
+
+    public void setNdtUploadKbit(Integer ndtUploadKbit) {
+        this.ndtUploadKbit = ndtUploadKbit;
+    }
+
+    public Boolean getImplausible() {
+        return implausible;
+    }
+
+    public void setImplausible(Boolean implausible) {
+        this.implausible = implausible;
+    }
+
+    public Boolean getPinned() {
+        return pinned;
+    }
+
+    public void setPinned(Boolean pinned) {
+        this.pinned = pinned;
+    }
+
+    public Integer getKgNr() {
+        return kgNr;
+    }
+
+    public void setKgNr(Integer kgNr) {
+        this.kgNr = kgNr;
+    }
+
+    public Integer getGkzSa() {
+        return gkzSa;
+    }
+
+    public void setGkzSa(Integer gkzSa) {
+        this.gkzSa = gkzSa;
+    }
+
+    public Integer getLandCover() {
+        return landCover;
+    }
+
+    public void setLandCover(Integer landCover) {
+        this.landCover = landCover;
+    }
+
+    public Integer getCellAreaCode() {
+        return cellAreaCode;
+    }
+
+    public void setCellAreaCode(Integer cellAreaCode) {
+        this.cellAreaCode = cellAreaCode;
+    }
+
+    public Integer getCellLocationId() {
+        return cellLocationId;
+    }
+
+    public void setCellLocationId(Integer cellLocationId) {
+        this.cellLocationId = cellLocationId;
+    }
+
+    public Integer getChannelNumber() {
+        return channelNumber;
+    }
+
+    public void setChannelNumber(Integer channelNumber) {
+        this.channelNumber = channelNumber;
+    }
+
+    public Integer getRadioBand() {
+        return radioBand;
+    }
+
+    public void setRadioBand(Integer radioBand) {
+        this.radioBand = radioBand;
+    }
+
+    public Integer getLteRsrq() {
+        return lteRsrq;
+    }
+
+    public void setLteRsrq(Integer lteRsrq) {
+        this.lteRsrq = lteRsrq;
+    }
+
+    public String getCatTechnology() {
+        return catTechnology;
+    }
+
+    public void setCatTechnology(String catTechnology) {
+        this.catTechnology = catTechnology;
+    }
+
+    public String getNetworkType() {
+        return networkType;
+    }
+
+    public void setNetworkType(String networkType) {
+        this.networkType = networkType;
+    }
+}

--- a/RMBTStatisticServer/src/at/rtr/rmbt/statisticServer/opendata/dto/OpenTestExportDTO.java
+++ b/RMBTStatisticServer/src/at/rtr/rmbt/statisticServer/opendata/dto/OpenTestExportDTO.java
@@ -3,6 +3,7 @@ package at.rtr.rmbt.statisticServer.opendata.dto;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.swagger.annotations.ApiModelProperty;
 
 //JSON property order for CSV output
 @JsonPropertyOrder({"open_uuid", "open_test_uuid", "time_utc", "cat_technology", "network_type", "lat", "long",
@@ -84,6 +85,8 @@ public class OpenTestExportDTO extends OpenTestDTO {
     }
 
 
+    @JsonProperty("loc_src")
+    @ApiModelProperty(reference = "OpenTestDetailsDTO/properties/loc_src")
     public String getLocSrc() {
         return locSrc;
     }
@@ -92,6 +95,7 @@ public class OpenTestExportDTO extends OpenTestDTO {
         this.locSrc = locSrc;
     }
 
+    @ApiModelProperty(reference = "OpenTestDetailsDTO/properties/gkz")
     public Integer getGkz() {
         return gkz;
     }
@@ -100,6 +104,8 @@ public class OpenTestExportDTO extends OpenTestDTO {
         this.gkz = gkz;
     }
 
+    @JsonProperty("zip_code")
+    @ApiModelProperty(reference = "OpenTestDetailsDTO/properties/zip_code")
     public Integer getZipCode() {
         return zipCode;
     }
@@ -108,6 +114,8 @@ public class OpenTestExportDTO extends OpenTestDTO {
         this.zipCode = zipCode;
     }
 
+    @JsonProperty("country_location")
+    @ApiModelProperty(reference = "OpenTestDetailsDTO/properties/country_location")
     public String getCountryLocation() {
         return countryLocation;
     }
@@ -116,6 +124,8 @@ public class OpenTestExportDTO extends OpenTestDTO {
         this.countryLocation = countryLocation;
     }
 
+    @JsonProperty("server_name")
+    @ApiModelProperty(reference = "OpenTestDetailsDTO/properties/server_name")
     public String getServerName() {
         return serverName;
     }
@@ -124,6 +134,8 @@ public class OpenTestExportDTO extends OpenTestDTO {
         this.serverName = serverName;
     }
 
+    @JsonProperty("test_duration")
+    @ApiModelProperty(reference = "OpenTestDetailsDTO/properties/test_duration")
     public Integer getTestDuration() {
         return testDuration;
     }
@@ -132,6 +144,8 @@ public class OpenTestExportDTO extends OpenTestDTO {
         this.testDuration = testDuration;
     }
 
+    @JsonProperty("num_threads")
+    @ApiModelProperty(reference = "OpenTestDetailsDTO/properties/num_threads")
     public Integer getNumThreads() {
         return numThreads;
     }
@@ -140,6 +154,8 @@ public class OpenTestExportDTO extends OpenTestDTO {
         this.numThreads = numThreads;
     }
 
+    @JsonProperty("client_version")
+    @ApiModelProperty(reference = "OpenTestDetailsDTO/properties/client_version")
     public String getClientVersion() {
         return clientVersion;
     }
@@ -148,6 +164,8 @@ public class OpenTestExportDTO extends OpenTestDTO {
         this.clientVersion = clientVersion;
     }
 
+    @JsonProperty("network_mcc_mnc")
+    @ApiModelProperty(reference = "OpenTestDetailsDTO/properties/network_mcc_mnc")
     public String getNetworkMccMnc() {
         return networkMccMnc;
     }
@@ -156,6 +174,8 @@ public class OpenTestExportDTO extends OpenTestDTO {
         this.networkMccMnc = networkMccMnc;
     }
 
+    @JsonProperty("network_name")
+    @ApiModelProperty(reference = "OpenTestDetailsDTO/properties/network_name")
     public String getNetworkName() {
         return networkName;
     }
@@ -164,6 +184,8 @@ public class OpenTestExportDTO extends OpenTestDTO {
         this.networkName = networkName;
     }
 
+    @JsonProperty("sim_mcc_mnc")
+    @ApiModelProperty(reference = "OpenTestDetailsDTO/properties/sim_mcc_mnc")
     public String getSimMccMnc() {
         return simMccMnc;
     }
@@ -172,6 +194,8 @@ public class OpenTestExportDTO extends OpenTestDTO {
         this.simMccMnc = simMccMnc;
     }
 
+    @JsonProperty("nat_type")
+    @ApiModelProperty(reference = "OpenTestDetailsDTO/properties/connection")
     public String getNatType() {
         return natType;
     }
@@ -180,6 +204,7 @@ public class OpenTestExportDTO extends OpenTestDTO {
         this.natType = natType;
     }
 
+    @ApiModelProperty(reference = "OpenTestDetailsDTO/properties/asn")
     public Integer getAsn() {
         return asn;
     }
@@ -188,6 +213,8 @@ public class OpenTestExportDTO extends OpenTestDTO {
         this.asn = asn;
     }
 
+    @JsonProperty("ip_anonym")
+    @ApiModelProperty(reference = "OpenTestDetailsDTO/properties/ip_anonym")
     public String getIpAnonym() {
         return ipAnonym;
     }
@@ -196,6 +223,8 @@ public class OpenTestExportDTO extends OpenTestDTO {
         this.ipAnonym = ipAnonym;
     }
 
+    @JsonProperty("ndt_download_kbit")
+    @ApiModelProperty(reference = "OpenTestDetailsDTO/properties/ndt_download_kbit")
     public Integer getNdtDownloadKbit() {
         return ndtDownloadKbit;
     }
@@ -204,6 +233,8 @@ public class OpenTestExportDTO extends OpenTestDTO {
         this.ndtDownloadKbit = ndtDownloadKbit;
     }
 
+    @JsonProperty("ndt_upload_kbit")
+    @ApiModelProperty(reference = "OpenTestDetailsDTO/properties/ndt_upload_kbit")
     public Integer getNdtUploadKbit() {
         return ndtUploadKbit;
     }
@@ -212,6 +243,7 @@ public class OpenTestExportDTO extends OpenTestDTO {
         this.ndtUploadKbit = ndtUploadKbit;
     }
 
+    @ApiModelProperty(reference = "OpenTestDetailsDTO/properties/implausible")
     public Boolean getImplausible() {
         return implausible;
     }
@@ -220,6 +252,7 @@ public class OpenTestExportDTO extends OpenTestDTO {
         this.implausible = implausible;
     }
 
+    @ApiModelProperty(reference = "OpenTestDetailsDTO/properties/pinned")
     public Boolean getPinned() {
         return pinned;
     }
@@ -228,6 +261,8 @@ public class OpenTestExportDTO extends OpenTestDTO {
         this.pinned = pinned;
     }
 
+    @JsonProperty("kg_nr")
+    @ApiModelProperty(reference = "OpenTestDetailsDTO/properties/kg_nr")
     public Integer getKgNr() {
         return kgNr;
     }
@@ -236,6 +271,8 @@ public class OpenTestExportDTO extends OpenTestDTO {
         this.kgNr = kgNr;
     }
 
+    @JsonProperty("gkz_sa")
+    @ApiModelProperty(reference = "OpenTestDetailsDTO/properties/gkz_sa")
     public Integer getGkzSa() {
         return gkzSa;
     }
@@ -244,6 +281,8 @@ public class OpenTestExportDTO extends OpenTestDTO {
         this.gkzSa = gkzSa;
     }
 
+    @JsonProperty("land_cover")
+    @ApiModelProperty(reference = "OpenTestDetailsDTO/properties/land_cover")
     public Integer getLandCover() {
         return landCover;
     }
@@ -252,6 +291,8 @@ public class OpenTestExportDTO extends OpenTestDTO {
         this.landCover = landCover;
     }
 
+    @JsonProperty("cell_area_code")
+    @ApiModelProperty(reference = "OpenTestDetailsDTO/properties/cell_area_code")
     public Integer getCellAreaCode() {
         return cellAreaCode;
     }
@@ -260,6 +301,8 @@ public class OpenTestExportDTO extends OpenTestDTO {
         this.cellAreaCode = cellAreaCode;
     }
 
+    @JsonProperty("cell_location_id")
+    @ApiModelProperty(reference = "OpenTestDetailsDTO/properties/cell_location_id")
     public Integer getCellLocationId() {
         return cellLocationId;
     }
@@ -268,6 +311,8 @@ public class OpenTestExportDTO extends OpenTestDTO {
         this.cellLocationId = cellLocationId;
     }
 
+    @JsonProperty("channel_number")
+    @ApiModelProperty(reference = "OpenTestDetailsDTO/properties/channel_number")
     public Integer getChannelNumber() {
         return channelNumber;
     }
@@ -276,6 +321,8 @@ public class OpenTestExportDTO extends OpenTestDTO {
         this.channelNumber = channelNumber;
     }
 
+    @JsonProperty("radio_band")
+    @ApiModelProperty(reference = "OpenTestDetailsDTO/properties/radio_band")
     public Integer getRadioBand() {
         return radioBand;
     }
@@ -284,6 +331,8 @@ public class OpenTestExportDTO extends OpenTestDTO {
         this.radioBand = radioBand;
     }
 
+    @JsonProperty("lte_rsrq")
+    @ApiModelProperty(reference = "OpenTestDetailsDTO/properties/lte_rsrq")
     public Integer getLteRsrq() {
         return lteRsrq;
     }
@@ -292,6 +341,8 @@ public class OpenTestExportDTO extends OpenTestDTO {
         this.lteRsrq = lteRsrq;
     }
 
+    @JsonProperty("cat_technology")
+    @ApiModelProperty(reference = "OpenTestDetailsDTO/properties/cat_technology")
     public String getCatTechnology() {
         return catTechnology;
     }
@@ -300,6 +351,8 @@ public class OpenTestExportDTO extends OpenTestDTO {
         this.catTechnology = catTechnology;
     }
 
+    @JsonProperty("network_type")
+    @ApiModelProperty(reference = "OpenTestDetailsDTO/properties/network_type")
     public String getNetworkType() {
         return networkType;
     }

--- a/RMBTStatisticServer/src/at/rtr/rmbt/statisticServer/opendata/dto/OpenTestGraphDTO.java
+++ b/RMBTStatisticServer/src/at/rtr/rmbt/statisticServer/opendata/dto/OpenTestGraphDTO.java
@@ -1,0 +1,61 @@
+package at.rtr.rmbt.statisticServer.opendata.dto;
+
+
+import java.util.*;
+
+public class OpenTestGraphDTO {
+
+    private List<SpeedGraphItemDTO> download = new ArrayList<>();
+    private List<SpeedGraphItemDTO> upload = new ArrayList<>();
+    private List<PingGraphItemDTO> ping = new ArrayList<>();
+    private List<SignalGraphItemDTO> signal = new ArrayList<>();
+    private List<LocationGraphDTO.LocationGraphItem> location = new ArrayList<>();
+
+
+
+    public List<SpeedGraphItemDTO> getDownload() {
+        return download;
+    }
+
+    public void setDownload(List<SpeedGraphItemDTO> download) {
+        this.download = download;
+    }
+
+    public List<SpeedGraphItemDTO> getUpload() {
+        return upload;
+    }
+
+    public void setUpload(List<SpeedGraphItemDTO> upload) {
+        this.upload = upload;
+    }
+
+    public List<PingGraphItemDTO> getPing() {
+        return ping;
+    }
+
+    public void setPing(List<PingGraphItemDTO> ping) {
+        this.ping = ping;
+    }
+
+    public List<SignalGraphItemDTO> getSignal() {
+        return signal;
+    }
+
+    public void setSignal(List<SignalGraphItemDTO> signal) {
+        this.signal = signal;
+    }
+
+    public List<LocationGraphDTO.LocationGraphItem> getLocation() {
+        return location;
+    }
+
+    public void setLocation(List<LocationGraphDTO.LocationGraphItem> location) {
+        this.location = location;
+    }
+
+
+
+
+
+
+}

--- a/RMBTStatisticServer/src/at/rtr/rmbt/statisticServer/opendata/dto/OpenTestGraphDTO.java
+++ b/RMBTStatisticServer/src/at/rtr/rmbt/statisticServer/opendata/dto/OpenTestGraphDTO.java
@@ -1,6 +1,8 @@
 package at.rtr.rmbt.statisticServer.opendata.dto;
 
 
+import io.swagger.annotations.ApiModelProperty;
+
 import java.util.*;
 
 public class OpenTestGraphDTO {
@@ -12,7 +14,7 @@ public class OpenTestGraphDTO {
     private List<LocationGraphDTO.LocationGraphItem> location = new ArrayList<>();
 
 
-
+    @ApiModelProperty(value = "Measurements of downloaded bytes at various times during the test.")
     public List<SpeedGraphItemDTO> getDownload() {
         return download;
     }
@@ -21,6 +23,7 @@ public class OpenTestGraphDTO {
         this.download = download;
     }
 
+    @ApiModelProperty(value = "Measurements of uploaded bytes at various times during the test.")
     public List<SpeedGraphItemDTO> getUpload() {
         return upload;
     }
@@ -29,6 +32,7 @@ public class OpenTestGraphDTO {
         this.upload = upload;
     }
 
+    @ApiModelProperty(value = "The client’s pings throughout the test")
     public List<PingGraphItemDTO> getPing() {
         return ping;
     }
@@ -37,6 +41,7 @@ public class OpenTestGraphDTO {
         this.ping = ping;
     }
 
+    @ApiModelProperty(value = "Measurements of signal strength and network type at various times during the test.")
     public List<SignalGraphItemDTO> getSignal() {
         return signal;
     }
@@ -45,6 +50,7 @@ public class OpenTestGraphDTO {
         this.signal = signal;
     }
 
+    @ApiModelProperty(value = "The client’s locations throughout the test.")
     public List<LocationGraphDTO.LocationGraphItem> getLocation() {
         return location;
     }
@@ -52,10 +58,6 @@ public class OpenTestGraphDTO {
     public void setLocation(List<LocationGraphDTO.LocationGraphItem> location) {
         this.location = location;
     }
-
-
-
-
 
 
 }

--- a/RMBTStatisticServer/src/at/rtr/rmbt/statisticServer/opendata/dto/OpenTestSearchDTO.java
+++ b/RMBTStatisticServer/src/at/rtr/rmbt/statisticServer/opendata/dto/OpenTestSearchDTO.java
@@ -1,6 +1,8 @@
 package at.rtr.rmbt.statisticServer.opendata.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModelProperty;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -12,6 +14,9 @@ public class OpenTestSearchDTO {
     private List<OpenTestDTO> results = new ArrayList<>();
     private List<String> invalidFields = new ArrayList<>();
 
+    @JsonProperty("next_cursor")
+    @ApiModelProperty(value = "cursor for next page",
+            example = "866505")
     public Long getNextCursor() {
         return nextCursor;
     }
@@ -20,6 +25,8 @@ public class OpenTestSearchDTO {
         this.nextCursor = nextCursor;
     }
 
+    @JsonProperty("results")
+    @ApiModelProperty(value = "test results matching the criteria")
     public List<OpenTestDTO> getResults() {
         return results;
     }
@@ -28,6 +35,9 @@ public class OpenTestSearchDTO {
         this.results = results;
     }
 
+    @JsonProperty("duration_ms")
+    @ApiModelProperty(value = "duration of the search request in milliseconds",
+            example = "234")
     public Long getDurationMs() {
         return durationMs;
     }
@@ -37,6 +47,8 @@ public class OpenTestSearchDTO {
     }
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonProperty("error")
+    @ApiModelProperty(value = "Error while conducting the search")
     public String getError() {
         return error;
     }
@@ -45,6 +57,9 @@ public class OpenTestSearchDTO {
         this.error = error;
     }
 
+    @JsonProperty("invalid_fields")
+    @ApiModelProperty(value = "Invalid fields in the search request",
+            example = "[\"download_kbit\"]")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public List<String> getInvalidFields() {
         return invalidFields;

--- a/RMBTStatisticServer/src/at/rtr/rmbt/statisticServer/opendata/dto/OpenTestSearchDTO.java
+++ b/RMBTStatisticServer/src/at/rtr/rmbt/statisticServer/opendata/dto/OpenTestSearchDTO.java
@@ -1,0 +1,58 @@
+package at.rtr.rmbt.statisticServer.opendata.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class OpenTestSearchDTO {
+    private Long nextCursor;
+    private Long durationMs;
+    private String error;
+    private List<OpenTestDTO> results = new ArrayList<>();
+    private List<String> invalidFields = new ArrayList<>();
+
+    public Long getNextCursor() {
+        return nextCursor;
+    }
+
+    public void setNextCursor(Long nextCursor) {
+        this.nextCursor = nextCursor;
+    }
+
+    public List<OpenTestDTO> getResults() {
+        return results;
+    }
+
+    public void setResults(List<OpenTestDTO> results) {
+        this.results = results;
+    }
+
+    public Long getDurationMs() {
+        return durationMs;
+    }
+
+    public void setDurationMs(Long durationMs) {
+        this.durationMs = durationMs;
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public String getError() {
+        return error;
+    }
+
+    public void setError(String error) {
+        this.error = error;
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public List<String> getInvalidFields() {
+        return invalidFields;
+    }
+
+    public void setInvalidFields(List<String> invalidFields) {
+        this.invalidFields = invalidFields;
+    }
+
+
+}

--- a/RMBTStatisticServer/src/at/rtr/rmbt/statisticServer/opendata/dto/PingGraphItemDTO.java
+++ b/RMBTStatisticServer/src/at/rtr/rmbt/statisticServer/opendata/dto/PingGraphItemDTO.java
@@ -1,5 +1,8 @@
 package at.rtr.rmbt.statisticServer.opendata.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModelProperty;
+
 public class PingGraphItemDTO {
     private double pingMs;
     private long timeElapsed;
@@ -8,6 +11,9 @@ public class PingGraphItemDTO {
 
     }
 
+    @JsonProperty("ping_ms")
+    @ApiModelProperty(value = "Ping (round-trip time) in milliseconds, measured on the server side.",
+            example = "8")
     public double getPingMs() {
         return pingMs;
     }
@@ -16,6 +22,9 @@ public class PingGraphItemDTO {
         this.pingMs = pingMs;
     }
 
+    @JsonProperty("time_elapsed")
+    @ApiModelProperty(value = "The time elapsed since the start of the test in milliseconds.",
+            example = "55")
     public long getTimeElapsed() {
         return timeElapsed;
     }

--- a/RMBTStatisticServer/src/at/rtr/rmbt/statisticServer/opendata/dto/PingGraphItemDTO.java
+++ b/RMBTStatisticServer/src/at/rtr/rmbt/statisticServer/opendata/dto/PingGraphItemDTO.java
@@ -1,0 +1,26 @@
+package at.rtr.rmbt.statisticServer.opendata.dto;
+
+public class PingGraphItemDTO {
+    private double pingMs;
+    private long timeElapsed;
+
+    public PingGraphItemDTO() {
+
+    }
+
+    public double getPingMs() {
+        return pingMs;
+    }
+
+    public void setPingMs(double pingMs) {
+        this.pingMs = pingMs;
+    }
+
+    public long getTimeElapsed() {
+        return timeElapsed;
+    }
+
+    public void setTimeElapsed(long timeElapsed) {
+        this.timeElapsed = timeElapsed;
+    }
+}

--- a/RMBTStatisticServer/src/at/rtr/rmbt/statisticServer/opendata/dto/SignalGraphItemDTO.java
+++ b/RMBTStatisticServer/src/at/rtr/rmbt/statisticServer/opendata/dto/SignalGraphItemDTO.java
@@ -1,0 +1,325 @@
+package at.rtr.rmbt.statisticServer.opendata.dto;
+
+import at.rtr.rmbt.util.BandCalculationUtil;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class SignalGraphItemDTO {
+
+    private long timeElapsed;
+    private String networkType;
+    private Integer signalStrength;
+    private Integer lteRsrp;
+    private Integer lteRsrq;
+    private String catTechnology;
+    private CellInfo2G cellInfo2G;
+    private CellInfo3G cellInfo3G;
+    private CellInfo4G cellInfo4G;
+
+
+    public SignalGraphItemDTO(long timeElapsed, String networkType, Integer signalStrength, Integer lteRsrp, Integer lteRsrq, String catTechnology, Integer locationId, Integer areaCode, Integer primaryScramblingCode, Integer channelNumber) {
+        this.timeElapsed = timeElapsed;
+        this.networkType = networkType;
+        locationId = (locationId == 0) ? null : locationId;
+        areaCode = (areaCode == 0) ? null : areaCode;
+        channelNumber = (channelNumber == 0) ? null : channelNumber;
+        primaryScramblingCode = (primaryScramblingCode == 0) ? null : primaryScramblingCode;
+
+        this.signalStrength = signalStrength;
+        this.lteRsrp = lteRsrp;
+        this.lteRsrq = lteRsrq;
+        this.catTechnology = catTechnology;
+
+        switch (catTechnology) {
+            case "2G":
+                cellInfo2G = new CellInfo2G(locationId, areaCode, primaryScramblingCode, channelNumber);
+                break;
+            case "3G":
+                cellInfo3G = new CellInfo3G(locationId, areaCode, primaryScramblingCode, channelNumber);
+                break;
+            case "4G":
+                cellInfo4G = new CellInfo4G(locationId, areaCode, primaryScramblingCode, channelNumber);
+                break;
+            default:
+                break;
+        }
+    }
+
+    public SignalGraphItemDTO(long timeElapsed, String networkType, Integer signalStrength, Integer lteRsrp, Integer lteRsrq, String catTechnology) {
+        this.timeElapsed = timeElapsed;
+        this.networkType = networkType;
+        signalStrength = (signalStrength == 0) ? null : signalStrength;
+        lteRsrp = (lteRsrp == 0) ? null : lteRsrp;
+        lteRsrq = (lteRsrq == 0) ? null : lteRsrq;
+        this.signalStrength = signalStrength;
+        this.lteRsrp = lteRsrp;
+        this.lteRsrq = lteRsrq;
+        this.catTechnology = catTechnology;
+    }
+
+    public SignalGraphItemDTO() {
+
+    }
+
+    public long getTimeElapsed() {
+        return timeElapsed;
+    }
+
+    public void setTimeElapsed(long timeElapsed) {
+        this.timeElapsed = timeElapsed;
+    }
+
+    public String getNetworkType() {
+        return networkType;
+    }
+
+    public void setNetworkType(String networkType) {
+        this.networkType = networkType;
+    }
+
+    public Integer getSignalStrength() {
+        if (signalStrength != null && signalStrength == 0) {
+            return null;
+        }
+        return signalStrength;
+    }
+
+    public void setSignalStrength(Integer signalStrength) {
+        this.signalStrength = signalStrength;
+    }
+
+    public Integer getLteRsrp() {
+        if (lteRsrp != null && lteRsrp == 0) {
+            return null;
+        }
+        return lteRsrp;
+    }
+
+    public void setLteRsrp(Integer lteRsrp) {
+        this.lteRsrp = lteRsrp;
+    }
+
+    public Integer getLteRsrq() {
+        if (lteRsrq != null && lteRsrq == 0) {
+            return null;
+        }
+        return lteRsrq;
+    }
+
+    public void setLteRsrq(Integer lteRsrq) {
+        this.lteRsrq = lteRsrq;
+    }
+
+    public String getCatTechnology() {
+        return catTechnology;
+    }
+
+    public void setCatTechnology(String catTechnology) {
+        this.catTechnology = catTechnology;
+    }
+
+    @JsonProperty("cell_info_2G")
+    public CellInfo2G getCellInfo2G() {
+        return cellInfo2G;
+    }
+
+    public void setCellInfo2G(CellInfo2G cellInfo2G) {
+        this.cellInfo2G = cellInfo2G;
+    }
+
+    @JsonProperty("cell_info_3G")
+    public CellInfo3G getCellInfo3G() {
+        return cellInfo3G;
+    }
+
+    public void setCellInfo3G(CellInfo3G cellInfo3G) {
+        this.cellInfo3G = cellInfo3G;
+    }
+
+    @JsonProperty("cell_info_4G")
+    public CellInfo4G getCellInfo4G() {
+        return cellInfo4G;
+    }
+
+    public void setCellInfo4G(CellInfo4G cellInfo4G) {
+        this.cellInfo4G = cellInfo4G;
+    }
+
+
+    public abstract static class CellInfo {
+        private BandCalculationUtil.FrequencyInformation fi;
+
+        protected void setFrequencyInformation(BandCalculationUtil.FrequencyInformation fi) {
+            this.setFi(fi);
+        }
+
+        public Double getFrequencyDl() {
+            return (getFi() == null) ? null : getFi().getFrequencyDL();
+        }
+
+        public Integer getBand() {
+            return (getFi() == null) ? null : getFi().getBand();
+        }
+
+        @JsonIgnore
+        public BandCalculationUtil.FrequencyInformation getFi() {
+            return fi;
+        }
+
+        public void setFi(BandCalculationUtil.FrequencyInformation fi) {
+            this.fi = fi;
+        }
+    }
+
+    public static class CellInfo2G extends CellInfo {
+        private Integer lac;
+        private Integer cid;
+        private Integer bsic;
+        private Integer arfcn;
+
+        public CellInfo2G(Integer locationId, Integer areaCode, Integer primaryScramblingCode, Integer channelNumber) {
+            setLac(locationId);
+            setCid(areaCode);
+            setBsic(primaryScramblingCode);
+            setArfcn(channelNumber);
+        }
+
+        public Integer getLac() {
+            return lac;
+        }
+
+        public Integer getCid() {
+            return cid;
+        }
+
+        public Integer getBsic() {
+            return bsic;
+        }
+
+        public Integer getArfcn() {
+            return arfcn;
+        }
+
+
+        public void setLac(Integer lac) {
+            this.lac = lac;
+        }
+
+        public void setCid(Integer cid) {
+            this.cid = cid;
+        }
+
+        public void setBsic(Integer bsic) {
+            this.bsic = bsic;
+        }
+
+        public void setArfcn(Integer arfcn) {
+            if (arfcn != null) {
+                setFrequencyInformation(BandCalculationUtil.getBandFromArfcn(arfcn));
+            }
+            this.arfcn = arfcn;
+        }
+    }
+
+    public static class CellInfo3G extends CellInfo {
+        private Integer lac;
+        private Integer cid;
+        private Integer psc;
+        private Integer uarfcn;
+
+        public CellInfo3G(Integer locationId, Integer areaCode, Integer primaryScramblingCode, Integer channelNumber) {
+            setLac(locationId);
+            setCid(areaCode);
+            setPsc(primaryScramblingCode);
+            setUarfcn(channelNumber);
+        }
+
+
+        public Integer getLac() {
+            return lac;
+        }
+
+        public Integer getCid() {
+            return cid;
+        }
+
+        public Integer getPsc() {
+            return psc;
+        }
+
+        public Integer getUarfcn() {
+            return uarfcn;
+        }
+
+
+        public void setLac(Integer lac) {
+            this.lac = lac;
+        }
+
+        public void setCid(Integer cid) {
+            this.cid = cid;
+        }
+
+        public void setPsc(Integer psc) {
+            this.psc = psc;
+        }
+
+        public void setUarfcn(Integer uarfcn) {
+            if (uarfcn != null) {
+                setFrequencyInformation(BandCalculationUtil.getBandFromUarfcn(uarfcn));
+            }
+            this.uarfcn = uarfcn;
+        }
+    }
+
+    public static class CellInfo4G extends CellInfo {
+        private Integer tac;
+        private Integer ci;
+        private Integer pci;
+        private Integer earfcn;
+
+        public CellInfo4G(Integer locationId, Integer areaCode, Integer primaryScramblingCode, Integer channelNumber) {
+            setTac(locationId);
+            setCi(areaCode);
+            setPci(primaryScramblingCode);
+            setEarfcn(channelNumber);
+        }
+
+
+        public Integer getTac() {
+            return tac;
+        }
+
+        public Integer getCi() {
+            return ci;
+        }
+
+        public Integer getPci() {
+            return pci;
+        }
+
+        public Integer getEarfcn() {
+            return earfcn;
+        }
+
+
+        public void setTac(Integer tac) {
+            this.tac = tac;
+        }
+
+        public void setCi(Integer ci) {
+            this.ci = ci;
+        }
+
+        public void setPci(Integer pci) {
+            this.pci = pci;
+        }
+
+        public void setEarfcn(Integer earfcn) {
+            if (earfcn != null) {
+                setFrequencyInformation(BandCalculationUtil.getBandFromEarfcn(earfcn));
+            }
+            this.earfcn = earfcn;
+        }
+    }
+}

--- a/RMBTStatisticServer/src/at/rtr/rmbt/statisticServer/opendata/dto/SignalGraphItemDTO.java
+++ b/RMBTStatisticServer/src/at/rtr/rmbt/statisticServer/opendata/dto/SignalGraphItemDTO.java
@@ -3,6 +3,7 @@ package at.rtr.rmbt.statisticServer.opendata.dto;
 import at.rtr.rmbt.util.BandCalculationUtil;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModelProperty;
 
 public class SignalGraphItemDTO {
 
@@ -61,6 +62,9 @@ public class SignalGraphItemDTO {
 
     }
 
+    @JsonProperty("time_elapsed")
+    @ApiModelProperty(value = "The time elapsed since the start of the test in milliseconds.",
+            example = "55")
     public long getTimeElapsed() {
         return timeElapsed;
     }
@@ -69,6 +73,9 @@ public class SignalGraphItemDTO {
         this.timeElapsed = timeElapsed;
     }
 
+    @JsonProperty("network_type")
+    @ApiModelProperty(value = "Type of the network, e.g. GSM, EDGE, UMTS, HSPA, LTE, LAN, WLAN…",
+            example = "LTE")
     public String getNetworkType() {
         return networkType;
     }
@@ -77,6 +84,9 @@ public class SignalGraphItemDTO {
         this.networkType = networkType;
     }
 
+    @JsonProperty("signal_strength")
+    @ApiModelProperty(value = "Signal strength (RSSI) in dBm.",
+            example = "-85")
     public Integer getSignalStrength() {
         if (signalStrength != null && signalStrength == 0) {
             return null;
@@ -88,6 +98,9 @@ public class SignalGraphItemDTO {
         this.signalStrength = signalStrength;
     }
 
+    @JsonProperty("lte_rsrp")
+    @ApiModelProperty(value = "LTE signal strength in dBm.",
+            example = "-77")
     public Integer getLteRsrp() {
         if (lteRsrp != null && lteRsrp == 0) {
             return null;
@@ -99,6 +112,9 @@ public class SignalGraphItemDTO {
         this.lteRsrp = lteRsrp;
     }
 
+    @JsonProperty("lte_rsrq")
+    @ApiModelProperty(value = "LTE signal quality in decibels.",
+            example = "-6")
     public Integer getLteRsrq() {
         if (lteRsrq != null && lteRsrq == 0) {
             return null;
@@ -110,6 +126,9 @@ public class SignalGraphItemDTO {
         this.lteRsrq = lteRsrq;
     }
 
+    @JsonProperty("cat_technology")
+    @ApiModelProperty(value = "Technology category of the network, e.g. “3G”, “4G”, “WLAN”.",
+            example = "3G")
     public String getCatTechnology() {
         return catTechnology;
     }
@@ -119,6 +138,7 @@ public class SignalGraphItemDTO {
     }
 
     @JsonProperty("cell_info_2G")
+    @ApiModelProperty(value = "Additional information about the used 2G radio cell")
     public CellInfo2G getCellInfo2G() {
         return cellInfo2G;
     }
@@ -128,6 +148,7 @@ public class SignalGraphItemDTO {
     }
 
     @JsonProperty("cell_info_3G")
+    @ApiModelProperty(value = "Additional information about the used 3G radio cell")
     public CellInfo3G getCellInfo3G() {
         return cellInfo3G;
     }
@@ -137,6 +158,7 @@ public class SignalGraphItemDTO {
     }
 
     @JsonProperty("cell_info_4G")
+    @ApiModelProperty(value = "Additional information about the used 4G radio cell")
     public CellInfo4G getCellInfo4G() {
         return cellInfo4G;
     }
@@ -153,10 +175,16 @@ public class SignalGraphItemDTO {
             this.setFi(fi);
         }
 
+        @JsonProperty("frequency_dl")
+        @ApiModelProperty(value = "Frequency of the downlink in MHz",
+                example = "934.4")
         public Double getFrequencyDl() {
             return (getFi() == null) ? null : getFi().getFrequencyDL();
         }
 
+        @JsonProperty("band")
+        @ApiModelProperty(value = "Band",
+                example = "1")
         public Integer getBand() {
             return (getFi() == null) ? null : getFi().getBand();
         }
@@ -184,18 +212,30 @@ public class SignalGraphItemDTO {
             setArfcn(channelNumber);
         }
 
+        @JsonProperty("lac")
+        @ApiModelProperty(value = "16-bit Location Area Code, 0..65535",
+                example = "47170")
         public Integer getLac() {
             return lac;
         }
 
+        @JsonProperty("cid")
+        @ApiModelProperty(value = "16-bit GSM Cell Identity described in TS 27.007, 0..65535",
+                example = "18804")
         public Integer getCid() {
             return cid;
         }
 
+        @JsonProperty("bsic")
+        @ApiModelProperty(value = "6-bit Base Station Identity Code",
+                example = "58")
         public Integer getBsic() {
             return bsic;
         }
 
+        @JsonProperty("arfcn")
+        @ApiModelProperty(value = "16-bit GSM Absolute RF Channel Number",
+                example = "1021")
         public Integer getArfcn() {
             return arfcn;
         }
@@ -235,18 +275,30 @@ public class SignalGraphItemDTO {
         }
 
 
+        @JsonProperty("lac")
+        @ApiModelProperty(value = "16-bit Location Area Code, 0..65535",
+                example = "2510")
         public Integer getLac() {
             return lac;
         }
 
+        @JsonProperty("cid")
+        @ApiModelProperty(value = "CID 28-bit UMTS Cell Identity described in TS 25.331, 0..268435455",
+                example = "9908484")
         public Integer getCid() {
             return cid;
         }
 
+        @JsonProperty("psc")
+        @ApiModelProperty(value = "9-bit UMTS Primary Scrambling Code described in TS 25.331, 0..511",
+                example = "27")
         public Integer getPsc() {
             return psc;
         }
 
+        @JsonProperty("uarfcn")
+        @ApiModelProperty(value = "16-bit UMTS Absolute RF Channel Number",
+                example = "10687")
         public Integer getUarfcn() {
             return uarfcn;
         }
@@ -285,19 +337,26 @@ public class SignalGraphItemDTO {
             setEarfcn(channelNumber);
         }
 
-
+        @ApiModelProperty(value = "16-bit Tracking Area Code",
+                example = "6710")
         public Integer getTac() {
             return tac;
         }
 
+        @ApiModelProperty(value = "28-bit Cell Identity",
+                example = "189954")
         public Integer getCi() {
             return ci;
         }
 
+        @ApiModelProperty(value = "Physical Cell Id 0..503",
+                example = "35")
         public Integer getPci() {
             return pci;
         }
 
+        @ApiModelProperty(value = "18-bit Absolute RF Channel Number",
+                example = "2850")
         public Integer getEarfcn() {
             return earfcn;
         }

--- a/RMBTStatisticServer/src/at/rtr/rmbt/statisticServer/opendata/dto/SpeedGraphItemDTO.java
+++ b/RMBTStatisticServer/src/at/rtr/rmbt/statisticServer/opendata/dto/SpeedGraphItemDTO.java
@@ -1,0 +1,33 @@
+package at.rtr.rmbt.statisticServer.opendata.dto;
+
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class SpeedGraphItemDTO {
+    protected long timeElapsedNs;
+    protected double bytesTotal;
+
+
+    public long getTimeElapsed() {
+        return Math.round(timeElapsedNs / 1e6);
+    }
+
+    public void setTimeElapsed(long timeElapsedNs) {
+        this.timeElapsedNs = timeElapsedNs;
+    }
+
+    public double getBytesTotal() {
+        return bytesTotal;
+    }
+
+    public void setBytesTotal(double bytesTotal) {
+        this.bytesTotal = bytesTotal;
+    }
+
+    public static class SpeedItemThreadwise extends SpeedGraphItemDTO {
+        @JsonProperty("time_elapsed_ns")
+        public long getTimeElapsed() {
+            return timeElapsedNs;
+        }
+    }
+}

--- a/RMBTStatisticServer/src/at/rtr/rmbt/statisticServer/opendata/dto/SpeedGraphItemDTO.java
+++ b/RMBTStatisticServer/src/at/rtr/rmbt/statisticServer/opendata/dto/SpeedGraphItemDTO.java
@@ -2,12 +2,16 @@ package at.rtr.rmbt.statisticServer.opendata.dto;
 
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModelProperty;
 
 public class SpeedGraphItemDTO {
     protected long timeElapsedNs;
     protected double bytesTotal;
 
 
+    @JsonProperty("time_elapsed")
+    @ApiModelProperty(value = "The time elapsed since the start of the test phase in milliseconds.",
+            example = "55")
     public long getTimeElapsed() {
         return Math.round(timeElapsedNs / 1e6);
     }
@@ -16,6 +20,9 @@ public class SpeedGraphItemDTO {
         this.timeElapsedNs = timeElapsedNs;
     }
 
+    @JsonProperty("bytes_total")
+    @ApiModelProperty(value = "The sum of all bytes transferred since the start of the test phase.",
+            example = "4096")
     public double getBytesTotal() {
         return bytesTotal;
     }
@@ -26,6 +33,8 @@ public class SpeedGraphItemDTO {
 
     public static class SpeedItemThreadwise extends SpeedGraphItemDTO {
         @JsonProperty("time_elapsed_ns")
+        @ApiModelProperty(value = "The time elapsed since the start of the test phase for this thread, in nanoseconds.",
+                example = "41183662")
         public long getTimeElapsed() {
             return timeElapsedNs;
         }


### PR DESCRIPTION
Code restructuring of StatisticServer Opendata APIs
* Auto-generate swagger documentation from code
* Use jackson json generation instead of org.json
* Use jackson csv generation instead of apache commons
* Use a jackson xlsx library to allow for xslsx export